### PR TITLE
Mapping assertions for regression tests

### DIFF
--- a/src/main/java/com/remondis/remap/AssertMapping.java
+++ b/src/main/java/com/remondis/remap/AssertMapping.java
@@ -13,6 +13,7 @@ import java.beans.PropertyDescriptor;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Creates a test for a {@link Mapper} object to assert the mapping specification. The expected mapping is to be
@@ -29,6 +30,10 @@ import java.util.Set;
  * @author schuettec
  */
 public class AssertMapping<S, D> {
+
+  static final String UNEXPECTED_TRANSFORMATION = "The following unexpected transformation were specified on the mapping:\n";
+
+  static final String EXPECTED_TRANSFORMATION = "The following expected transformation were not specified on the mapping:\n";
 
   static final String TRANSFORMATION_ALREADY_ADDED = "The specified transformation was already added as an assertion";
 
@@ -100,8 +105,45 @@ public class AssertMapping<S, D> {
   public void ensure() throws AssertionError {
     checkReplaceTransformations();
     checkTransformations();
+    checkReplaceFunctions();
   }
 
+  /**
+   * This method checks the replace functions against the following scenarios:
+   * <ol>
+   * <li>The functions do not throw an exception when invoked using sample values
+   * <li>
+   * <li>The function is null-safe if null strategy is not skip-when-null</li>
+   * </ol>
+   */
+  @SuppressWarnings("rawtypes")
+  private void checkReplaceFunctions() {
+    Set<Transformation> mappings = mapper.getMapping()
+                                         .getMappings();
+    mappings.stream()
+            .filter(t -> {
+              return (t instanceof ReplaceTransformation);
+            })
+            .map(t -> {
+              return (ReplaceTransformation) t;
+            })
+            .forEach(r -> {
+              Transform<?, ?> transformation = r.getTransformation();
+              if (!r.isSkipWhenNull()) {
+                try {
+                  transformation.transform(null);
+                } catch (Throwable t) {
+                  throw new AssertionError("The specified transformation function is not null-safe for operation:\n"
+                      + t.toString(), t);
+                }
+              }
+            });
+  }
+
+  /**
+   * This method checks that the expected replace transformations and the actual replace transformations have equal null
+   * strategies.
+   */
   @SuppressWarnings("rawtypes")
   private void checkReplaceTransformations() {
     Set<Transformation> mappings = mapper.getMapping()
@@ -115,24 +157,22 @@ public class AssertMapping<S, D> {
               return (ReplaceTransformation) t;
             })
             .forEach(replace -> {
-
-              @SuppressWarnings("rawtypes")
-              Optional<ReplaceTransformation> sameTransformation = assertedTransformations.stream()
-                                                                                          .filter(t -> {
-                                                                                            return (t instanceof ReplaceTransformation);
-                                                                                          })
-                                                                                          .map(t -> {
-                                                                                            return (ReplaceTransformation) t;
-                                                                                          })
-                                                                                          .filter(r -> {
-                                                                                            return r.getSourceProperty()
-                                                                                                    .equals(replace.getSourceProperty());
-                                                                                          })
-                                                                                          .filter(r -> {
-                                                                                            return r.getDestinationProperty()
-                                                                                                    .equals(replace.getDestinationProperty());
-                                                                                          })
-                                                                                          .findFirst();
+              Optional<ReplaceTransformation> sameTransformation = assertedTransformations().stream()
+                                                                                            .filter(t -> {
+                                                                                              return (t instanceof ReplaceTransformation);
+                                                                                            })
+                                                                                            .map(t -> {
+                                                                                              return (ReplaceTransformation) t;
+                                                                                            })
+                                                                                            .filter(r -> {
+                                                                                              return r.getSourceProperty()
+                                                                                                      .equals(replace.getSourceProperty());
+                                                                                            })
+                                                                                            .filter(r -> {
+                                                                                              return r.getDestinationProperty()
+                                                                                                      .equals(replace.getDestinationProperty());
+                                                                                            })
+                                                                                            .findFirst();
               if (sameTransformation.isPresent()) {
                 ReplaceTransformation assertedReplaceTransformation = sameTransformation.get();
                 // Check if the configured replace transformation has the same skip-null configuration than the asserted
@@ -142,23 +182,46 @@ public class AssertMapping<S, D> {
                       + replace.toString() + "\n" + assertedTransformations.toString());
                 }
               }
-
             });
-
   }
 
   private void checkTransformations() {
     Set<Transformation> mappings = getMapping().getMappings();
+    Set<Transformation> assertedTransformations = assertedTransformations();
+
     // we have to check that the mapping list contains all asserted transformations
     mappings.removeAll(assertedTransformations);
+    assertedTransformations.removeAll(getMapping().getMappings());
+
+    if (!assertedTransformations.isEmpty()) {
+      throw new AssertionError(EXPECTED_TRANSFORMATION + listCollection(assertedTransformations));
+    }
+
     if (!mappings.isEmpty()) {
       // if there are more elements left, the remaining transformations must be MapTransformations
-      for (Transformation t : mappings) {
-        if (!(t instanceof MapTransformation)) {
-          throw new AssertionError("An unexpected transformation was specified on the mapping:\n" + t.toString());
-        }
+      Set<Transformation> unexpectedTransformations = mappings.stream()
+                                                              .filter(t -> {
+                                                                return !(t instanceof MapTransformation);
+                                                              })
+                                                              .collect(Collectors.toSet());
+      if (!unexpectedTransformations.isEmpty()) {
+        throw new AssertionError(UNEXPECTED_TRANSFORMATION + listCollection(unexpectedTransformations));
       }
     }
+  }
+
+  private String listCollection(Set<Transformation> transformations) {
+    StringBuilder b = new StringBuilder();
+    transformations.stream()
+                   .forEach(t -> {
+                     b.append("- " + t.toString())
+                      .append("\n");
+                   });
+    return b.toString();
+  }
+
+  private Set<Transformation> assertedTransformations() {
+    return new HashSet<>(assertedTransformations);
   }
 
   void addAssertion(Transformation transformation) {

--- a/src/main/java/com/remondis/remap/AssertMapping.java
+++ b/src/main/java/com/remondis/remap/AssertMapping.java
@@ -1,0 +1,172 @@
+package com.remondis.remap;
+
+import static com.remondis.remap.Mapping.OMIT_FIELD_DEST;
+import static com.remondis.remap.Mapping.OMIT_FIELD_SOURCE;
+import static com.remondis.remap.Mapping.getPropertyFromFieldSelector;
+import static com.remondis.remap.Mapping.getTypedPropertyFromFieldSelector;
+import static com.remondis.remap.OmitTransformation.omitDestination;
+import static com.remondis.remap.OmitTransformation.omitSource;
+import static com.remondis.remap.ReassignBuilder.ASSIGN;
+import static com.remondis.remap.ReplaceBuilder.TRANSFORM;
+
+import java.beans.PropertyDescriptor;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Creates a test for a {@link Mapper} object to assert the mapping specification. The expected mapping is to be
+ * configured on this object. The method {@link #ensure()} then performs the assertions against the actual configured
+ * mapping configuration of the specified mapper and performs checks using the specified transformation functions.
+ * Transformation functions specified for the `replace` operation are checked against <code>null</code> and sample
+ * values. It is expected that those test invocations do not throw an exception.
+ * 
+ * @param <S>
+ *          The type of the source objects
+ * @param <D>
+ *          The type of the destination objects.
+ *
+ * @author schuettec
+ */
+public class AssertMapping<S, D> {
+
+  static final String TRANSFORMATION_ALREADY_ADDED = "The specified transformation was already added as an assertion";
+
+  private Mapper<S, D> mapper;
+
+  private Set<Transformation> assertedTransformations;
+
+  public AssertMapping(Mapper<S, D> mapper) {
+    this.mapper = mapper;
+    this.assertedTransformations = new HashSet<>();
+  }
+
+  public static <S, D> AssertMapping<S, D> of(Mapper<S, D> mapper) {
+    return new AssertMapping<S, D>(mapper);
+  }
+
+  public <RS> ReassignAssertBuilder<S, D, RS> expectReassign(TypedSelector<RS, S> sourceSelector) {
+    TypedPropertyDescriptor<RS> typedSourceProperty = getTypedPropertyFromFieldSelector(ASSIGN,
+                                                                                        getMapping().getSource(),
+                                                                                        sourceSelector);
+    ReassignAssertBuilder<S, D, RS> reassignBuilder = new ReassignAssertBuilder<S, D, RS>(typedSourceProperty,
+                                                                                          getMapping().getDestination(),
+                                                                                          this);
+    return reassignBuilder;
+  }
+
+  public <RD, RS> ReplaceAssertBuilder<S, D, RD, RS> expectReplace(TypedSelector<RS, S> sourceSelector,
+      TypedSelector<RD, D> destinationSelector) {
+    TypedPropertyDescriptor<RS> sourceProperty = getTypedPropertyFromFieldSelector(TRANSFORM, getMapping().getSource(),
+                                                                                   sourceSelector);
+    TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(TRANSFORM,
+                                                                                 getMapping().getDestination(),
+                                                                                 destinationSelector);
+
+    ReplaceAssertBuilder<S, D, RD, RS> builder = new ReplaceAssertBuilder<>(sourceProperty, destProperty, this);
+    return builder;
+  }
+
+  private void _add(Transformation transformation) {
+    if (assertedTransformations.contains(transformation)) {
+      throw new AssertionError(TRANSFORMATION_ALREADY_ADDED);
+    }
+    assertedTransformations.add(transformation);
+  }
+
+  public AssertMapping<S, D> expectOmitInSource(FieldSelector<S> sourceSelector) {
+    // Omit in destination
+    PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(OMIT_FIELD_SOURCE, getMapping().getSource(),
+                                                                         sourceSelector);
+    OmitTransformation omitSource = omitSource(getMapping(), propertyDescriptor);
+    _add(omitSource);
+    return this;
+  }
+
+  public AssertMapping<S, D> expectOmitInDestination(FieldSelector<D> destinationSelector) {
+    PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(OMIT_FIELD_DEST, getMapping().getDestination(),
+                                                                         destinationSelector);
+    OmitTransformation omitDestination = omitDestination(getMapping(), propertyDescriptor);
+    _add(omitDestination);
+    return this;
+  }
+
+  /**
+   * Performes the specified assertions against sample objects that will be created by the assertion library.
+   * 
+   * @throws AssertionError
+   *           Thrown if an assertion made about the {@link Mapper} object failed.
+   */
+  public void ensure() throws AssertionError {
+    checkReplaceTransformations();
+    checkTransformations();
+  }
+
+  @SuppressWarnings("rawtypes")
+  private void checkReplaceTransformations() {
+    Set<Transformation> mappings = mapper.getMapping()
+                                         .getMappings();
+
+    mappings.stream()
+            .filter(t -> {
+              return (t instanceof ReplaceTransformation);
+            })
+            .map(t -> {
+              return (ReplaceTransformation) t;
+            })
+            .forEach(replace -> {
+
+              @SuppressWarnings("rawtypes")
+              Optional<ReplaceTransformation> sameTransformation = assertedTransformations.stream()
+                                                                                          .filter(t -> {
+                                                                                            return (t instanceof ReplaceTransformation);
+                                                                                          })
+                                                                                          .map(t -> {
+                                                                                            return (ReplaceTransformation) t;
+                                                                                          })
+                                                                                          .filter(r -> {
+                                                                                            return r.getSourceProperty()
+                                                                                                    .equals(replace.getSourceProperty());
+                                                                                          })
+                                                                                          .filter(r -> {
+                                                                                            return r.getDestinationProperty()
+                                                                                                    .equals(replace.getDestinationProperty());
+                                                                                          })
+                                                                                          .findFirst();
+              if (sameTransformation.isPresent()) {
+                ReplaceTransformation assertedReplaceTransformation = sameTransformation.get();
+                // Check if the configured replace transformation has the same skip-null configuration than the asserted
+                // one and throw if not
+                if (replace.isSkipWhenNull() != assertedReplaceTransformation.isSkipWhenNull()) {
+                  throw new AssertionError("The replace transformation specified by the mapper has a different null value strategy than the expected transformation:\n"
+                      + replace.toString() + "\n" + assertedTransformations.toString());
+                }
+              }
+
+            });
+
+  }
+
+  private void checkTransformations() {
+    Set<Transformation> mappings = getMapping().getMappings();
+    // we have to check that the mapping list contains all asserted transformations
+    mappings.removeAll(assertedTransformations);
+    if (!mappings.isEmpty()) {
+      // if there are more elements left, the remaining transformations must be MapTransformations
+      for (Transformation t : mappings) {
+        if (!(t instanceof MapTransformation)) {
+          throw new AssertionError("An unexpected transformation was specified on the mapping:\n" + t.toString());
+        }
+      }
+    }
+  }
+
+  void addAssertion(Transformation transformation) {
+    _add(transformation);
+  }
+
+  Mapping<S, D> getMapping() {
+    return mapper.getMapping();
+  }
+
+}

--- a/src/main/java/com/remondis/remap/OmitTransformation.java
+++ b/src/main/java/com/remondis/remap/OmitTransformation.java
@@ -1,7 +1,7 @@
 package com.remondis.remap;
 
-import static com.remondis.remap.Lang.*;
-import static com.remondis.remap.Properties.*;
+import static com.remondis.remap.Lang.denyNull;
+import static com.remondis.remap.Properties.asString;
 
 import java.beans.PropertyDescriptor;
 
@@ -29,7 +29,7 @@ class OmitTransformation extends Transformation {
    *          the property to omit in the destination
    * @return Returns a new {@link OmitTransformation}.
    */
-   static OmitTransformation omitDestination(Mapping<?, ?> mapping, PropertyDescriptor destinationProperty) {
+  static OmitTransformation omitDestination(Mapping<?, ?> mapping, PropertyDescriptor destinationProperty) {
     denyNull("mapping", mapping);
     denyNull("destinationProperty", destinationProperty);
     return new OmitTransformation(mapping, null, destinationProperty);
@@ -44,7 +44,7 @@ class OmitTransformation extends Transformation {
    *          the property to omit in the source
    * @return Returns a new {@link OmitTransformation}.
    */
-   static OmitTransformation omitSource(Mapping<?, ?> mapping, PropertyDescriptor sourceProperty) {
+  static OmitTransformation omitSource(Mapping<?, ?> mapping, PropertyDescriptor sourceProperty) {
     denyNull("mapping", mapping);
     denyNull("destinationProperty", sourceProperty);
     return new OmitTransformation(mapping, sourceProperty, null);

--- a/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
@@ -1,0 +1,55 @@
+package com.remondis.remap;
+
+import static com.remondis.remap.Mapping.getTypedPropertyFromFieldSelector;
+
+import java.beans.PropertyDescriptor;
+
+/**
+ * This class is used to build an assertion about a reassign operation.
+ * 
+ * @param <S>
+ *          The source object
+ * @param <D>
+ *          The destination object
+ * @param <RS>
+ *          The type of the selected field.
+ * 
+ * @author schuettec
+ */
+public class ReassignAssertBuilder<S, D, RS> {
+
+  private TypedPropertyDescriptor<RS> tSourceProperty;
+
+  private AssertMapping<S, D> asserts;
+
+  private Class<D> destination;
+
+  ReassignAssertBuilder(TypedPropertyDescriptor<RS> tSourceProperty, Class<D> destination,
+      AssertMapping<S, D> asserts) {
+    super();
+    this.tSourceProperty = tSourceProperty;
+    this.asserts = asserts;
+    this.destination = destination;
+  }
+
+  /**
+   * Reassings a source field to the specified destination field.
+   * 
+   * @param destinationSelector
+   *          {@link TypedSelector} to select the destination field.
+   *
+   * @return Returns the {@link Mapping} for further mapping configuration.
+   */
+  public AssertMapping<S, D> to(TypedSelector<RS, D> destinationSelector) {
+    TypedPropertyDescriptor<RS> typedDestProperty = getTypedPropertyFromFieldSelector(ReassignBuilder.ASSIGN,
+                                                                                      this.destination,
+                                                                                      destinationSelector);
+    PropertyDescriptor sourceProperty = tSourceProperty.property;
+    PropertyDescriptor destinationProperty = typedDestProperty.property;
+    ReassignTransformation transformation = new ReassignTransformation(asserts.getMapping(), sourceProperty,
+                                                                       destinationProperty);
+    asserts.addAssertion(transformation);
+    return asserts;
+  }
+
+}

--- a/src/main/java/com/remondis/remap/ReassignBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignBuilder.java
@@ -1,16 +1,25 @@
 package com.remondis.remap;
 
+import static com.remondis.remap.Mapping.getTypedPropertyFromFieldSelector;
+
 import java.beans.PropertyDescriptor;
 
 public class ReassignBuilder<S, D, RS> {
 
-  private static final String ASSIGN = "assign";
+  static final String ASSIGN = "assign";
 
-  TypedPropertyDescriptor<RS> tSourceProperty;
+  private TypedPropertyDescriptor<RS> tSourceProperty;
 
-  Mapping<S, D> mapping;
+  private Mapping<S, D> mapping;
 
-  Class<D> destination;
+  private Class<D> destination;
+
+  ReassignBuilder(TypedPropertyDescriptor<RS> tSourceProperty, Class<D> destination, Mapping<S, D> mapping) {
+    super();
+    this.tSourceProperty = tSourceProperty;
+    this.mapping = mapping;
+    this.destination = destination;
+  }
 
   /**
    * Reassings a source field to the specified destination field.
@@ -21,8 +30,8 @@ public class ReassignBuilder<S, D, RS> {
    * @return Returns the {@link Mapping} for further mapping configuration.
    */
   public Mapping<S, D> to(TypedSelector<RS, D> destinationSelector) {
-    TypedPropertyDescriptor<RS> typedDestProperty = mapping.getTypedPropertyFromFieldSelector(ASSIGN, this.destination,
-        destinationSelector);
+    TypedPropertyDescriptor<RS> typedDestProperty = getTypedPropertyFromFieldSelector(ASSIGN, destination,
+                                                                                      destinationSelector);
     PropertyDescriptor sourceProperty = tSourceProperty.property;
     PropertyDescriptor destinationProperty = typedDestProperty.property;
     ReassignTransformation transformation = new ReassignTransformation(mapping, sourceProperty, destinationProperty);

--- a/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
@@ -1,0 +1,52 @@
+package com.remondis.remap;
+
+import static com.remondis.remap.Lang.denyNull;
+
+/**
+ * Builder to assert a replace operation on a {@link Mapper} object using {@link AssertMapping}.
+ * 
+ * @param <S>
+ *          The source type
+ * @param <D>
+ *          The destination type
+ * @param <RS>
+ *          The type of the source field
+ * @param <RD>
+ *          The type of the destination field
+ *
+ * @author schuettec
+ */
+public class ReplaceAssertBuilder<S, D, RD, RS> {
+
+  private TypedPropertyDescriptor<RS> sourceProperty;
+  private TypedPropertyDescriptor<RD> destProperty;
+  private AssertMapping<S, D> asserts;
+
+  ReplaceAssertBuilder(TypedPropertyDescriptor<RS> sourceProperty, TypedPropertyDescriptor<RD> destProperty,
+      AssertMapping<S, D> asserts) {
+    super();
+    this.sourceProperty = sourceProperty;
+    this.destProperty = destProperty;
+    this.asserts = asserts;
+  }
+
+  public AssertMapping<S, D> andTest(Transform<RD, RS> transformation) {
+    denyNull("tranfromation", transformation);
+    ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(asserts.getMapping(),
+                                                                              sourceProperty.property,
+                                                                              destProperty.property, transformation,
+                                                                              false);
+    asserts.addAssertion(replace);
+    return asserts;
+  }
+
+  public AssertMapping<S, D> andTestButSkipWhenNull(Transform<RD, RS> transformation) {
+    denyNull("tranfromation", transformation);
+    ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(asserts.getMapping(),
+                                                                              sourceProperty.property,
+                                                                              destProperty.property, transformation,
+                                                                              true);
+    asserts.addAssertion(replace);
+    return asserts;
+  }
+}

--- a/src/main/java/com/remondis/remap/ReplaceBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceBuilder.java
@@ -1,24 +1,37 @@
 package com.remondis.remap;
 
-public class ReplaceBuilder<S, D, RD, RS> {
+import static com.remondis.remap.Lang.denyNull;
 
-  TypedPropertyDescriptor<RS> sourceProperty;
-  TypedPropertyDescriptor<RD> destProperty;
-  public Mapping<S, D> mapping;
+public class ReplaceBuilder<S, D, RD, RS> {
+  static final String TRANSFORM = "transform";
+
+  private TypedPropertyDescriptor<RS> sourceProperty;
+  private TypedPropertyDescriptor<RD> destProperty;
+  private Mapping<S, D> mapping;
+
+  ReplaceBuilder(TypedPropertyDescriptor<RS> sourceProperty, TypedPropertyDescriptor<RD> destProperty,
+      Mapping<S, D> mapping) {
+    super();
+    this.sourceProperty = sourceProperty;
+    this.destProperty = destProperty;
+    this.mapping = mapping;
+  }
 
   /**
    * Transforms the selected fields with applying the specified transform function on the source value.
    * <b>Note: The transform function must check the source value for <code>null</code> itself. Use
    * {@link #withSkipWhenNull(Transform)} to skip on <code>null</code> input values.</b>
    *
-   * @param transform
+   * @param transformation
    *          The transform function.
    * @return Returns the {@link Mapping} for further mapping configuration.
    */
-  public Mapping<S, D> with(Transform<RD, RS> transform) {
-    ReplaceTransformation<RD, RS> transformation = new ReplaceTransformation<RD, RS>(mapping, sourceProperty.property,
-        destProperty.property, transform, false);
-    mapping.addMapping(sourceProperty.property, destProperty.property, transformation);
+  public Mapping<S, D> with(Transform<RD, RS> transformation) {
+    denyNull("tranformation", transformation);
+    ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(mapping, sourceProperty.property,
+                                                                              destProperty.property, transformation,
+                                                                              false);
+    mapping.addMapping(sourceProperty.property, destProperty.property, replace);
     return mapping;
   }
 
@@ -26,14 +39,16 @@ public class ReplaceBuilder<S, D, RD, RS> {
    * Transforms the selected fields with applying the specified transform function on the source value. <b>This method
    * skips the execution of the transform function if the source value is null.</b>
    *
-   * @param transform
+   * @param transformation
    *          The transform function.
    * @return Returns the {@link Mapping} for further mapping configuration.
    */
-  public Mapping<S, D> withSkipWhenNull(Transform<RD, RS> transform) {
-    ReplaceTransformation<RD, RS> transformation = new ReplaceTransformation<RD, RS>(mapping, sourceProperty.property,
-        destProperty.property, transform, true);
-    mapping.addMapping(sourceProperty.property, destProperty.property, transformation);
+  public Mapping<S, D> withSkipWhenNull(Transform<RD, RS> transformation) {
+    denyNull("tranformation", transformation);
+    ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(mapping, sourceProperty.property,
+                                                                              destProperty.property, transformation,
+                                                                              true);
+    mapping.addMapping(sourceProperty.property, destProperty.property, replace);
     return mapping;
   }
 }

--- a/src/main/java/com/remondis/remap/ReplaceTransformation.java
+++ b/src/main/java/com/remondis/remap/ReplaceTransformation.java
@@ -20,8 +20,7 @@ class ReplaceTransformation<RD, RS> extends Transformation {
   private static final String REPLACE_MSG = "Replacing %s\n           with %s using transformation";
   private static final String REPLACE_SKIPPED_MSG = "Replacing but skipping when null %s\n           with %s using transformation";
 
-  @SuppressWarnings("rawtypes")
-  private Transform transformation;
+  private Transform<RD, RS> transformation;
   private boolean skipWhenNull;
 
   ReplaceTransformation(Mapping<?, ?> mapping, PropertyDescriptor sourceProperty, PropertyDescriptor destProperty,
@@ -42,7 +41,7 @@ class ReplaceTransformation<RD, RS> extends Transformation {
     }
 
     @SuppressWarnings("unchecked")
-    Object destinationValue = transformation.transform(sourceValue);
+    RD destinationValue = transformation.transform((RS) sourceValue);
     writeOrFail(destinationProperty, destination, destinationValue);
   }
 
@@ -57,6 +56,10 @@ class ReplaceTransformation<RD, RS> extends Transformation {
     } else {
       return String.format(REPLACE_MSG, asString(sourceProperty), asString(destinationProperty));
     }
+  }
+
+  Transform<RD, RS> getTransformation() {
+    return transformation;
   }
 
   boolean isSkipWhenNull() {

--- a/src/main/java/com/remondis/remap/ReplaceTransformation.java
+++ b/src/main/java/com/remondis/remap/ReplaceTransformation.java
@@ -1,6 +1,6 @@
 package com.remondis.remap;
 
-import static com.remondis.remap.Lang.*;
+import static com.remondis.remap.Properties.asString;
 
 import java.beans.PropertyDescriptor;
 
@@ -17,6 +17,9 @@ import java.beans.PropertyDescriptor;
  */
 class ReplaceTransformation<RD, RS> extends Transformation {
 
+  private static final String REPLACE_MSG = "Replacing %s\n           with %s using transformation";
+  private static final String REPLACE_SKIPPED_MSG = "Replacing but skipping when null %s\n           with %s using transformation";
+
   @SuppressWarnings("rawtypes")
   private Transform transformation;
   private boolean skipWhenNull;
@@ -24,7 +27,6 @@ class ReplaceTransformation<RD, RS> extends Transformation {
   ReplaceTransformation(Mapping<?, ?> mapping, PropertyDescriptor sourceProperty, PropertyDescriptor destProperty,
       Transform<RD, RS> transformation, boolean skipWhenNull) {
     super(mapping, sourceProperty, destProperty);
-    denyNull("transformation", transformation);
     this.transformation = transformation;
     this.skipWhenNull = skipWhenNull;
   }
@@ -46,6 +48,19 @@ class ReplaceTransformation<RD, RS> extends Transformation {
 
   @Override
   protected void validateTransformation() throws MappingException {
+  }
+
+  @Override
+  public String toString() {
+    if (skipWhenNull) {
+      return String.format(REPLACE_SKIPPED_MSG, asString(sourceProperty), asString(destinationProperty));
+    } else {
+      return String.format(REPLACE_MSG, asString(sourceProperty), asString(destinationProperty));
+    }
+  }
+
+  boolean isSkipWhenNull() {
+    return skipWhenNull;
   }
 
 }

--- a/src/main/java/com/remondis/remap/Transformation.java
+++ b/src/main/java/com/remondis/remap/Transformation.java
@@ -164,4 +164,35 @@ abstract class Transformation {
     return destinationProperty;
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((destinationProperty == null) ? 0 : destinationProperty.hashCode());
+    result = prime * result + ((sourceProperty == null) ? 0 : sourceProperty.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Transformation other = (Transformation) obj;
+    if (destinationProperty == null) {
+      if (other.destinationProperty != null)
+        return false;
+    } else if (!destinationProperty.equals(other.destinationProperty))
+      return false;
+    if (sourceProperty == null) {
+      if (other.sourceProperty != null)
+        return false;
+    } else if (!sourceProperty.equals(other.sourceProperty))
+      return false;
+    return true;
+  }
+
 }

--- a/src/test/java/com/remondis/remap/AssertMappingTest.java
+++ b/src/test/java/com/remondis/remap/AssertMappingTest.java
@@ -1,0 +1,223 @@
+package com.remondis.remap;
+
+import static com.remondis.remap.AssertMapping.TRANSFORMATION_ALREADY_ADDED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.remondis.remap.assertion.A;
+import com.remondis.remap.assertion.AResource;
+import com.remondis.remap.assertion.B;
+import com.remondis.remap.assertion.BResource;
+
+public class AssertMappingTest {
+
+  @Test
+  public void shouldThrowAssertionError() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+                                          .to(BResource.class)
+                                          .mapper();
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+                                         .to(AResource.class)
+                                         .reassign(A::getString)
+                                         .to(AResource::getAnotherString)
+                                         .replace(A::getInteger, AResource::getIntegerAsString)
+                                         .with(String::valueOf)
+                                         .omitInSource(A::getOmitted)
+                                         .omitInDestination(AResource::getOmitted)
+                                         .useMapper(bMapper)
+                                         .mapper();
+
+    // Assert an error when defining expecteOmitInSource multiple times.
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectOmitInSource(A::getOmitted)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expecteOmitInDestination multiple times.
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expectReassign multiple times.
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expectReplace multiple times.
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expectReplace multiple times.
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTestButSkipWhenNull(String::valueOf)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTestButSkipWhenNull(String::valueOf)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expectReplace multiple times but different null-skip configuration
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTestButSkipWhenNull(String::valueOf)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+    // Assert an error when defining expectReplace multiple times but different null-skip configuration
+    assertThatThrownBy(() -> {
+      AssertMapping.of(mapper)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTestButSkipWhenNull(String::valueOf)
+                   .expectReassign(A::getString)
+                   .to(AResource::getAnotherString)
+                   .expectOmitInSource(A::getOmitted)
+                   .expectOmitInDestination(AResource::getOmitted)
+                   .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                   .andTest(String::valueOf)
+                   .ensure();
+    }).isInstanceOf(AssertionError.class)
+      .hasMessage(TRANSFORMATION_ALREADY_ADDED)
+      .hasNoCause();
+
+  }
+
+  @Test(expected = AssertionError.class)
+  public void shouldDetectExpectedNoSkipWhenNull() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+                                          .to(BResource.class)
+                                          .mapper();
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+                                         .to(AResource.class)
+                                         .reassign(A::getString)
+                                         .to(AResource::getAnotherString)
+                                         .replace(A::getInteger, AResource::getIntegerAsString)
+                                         .withSkipWhenNull(String::valueOf)
+                                         .omitInSource(A::getOmitted)
+                                         .omitInDestination(AResource::getOmitted)
+                                         .useMapper(bMapper)
+                                         .mapper();
+
+    AssertMapping<A, AResource> asserts = AssertMapping.of(mapper)
+                                                       .expectReassign(A::getString)
+                                                       .to(AResource::getAnotherString)
+                                                       .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                                                       .andTest(String::valueOf)
+                                                       .expectOmitInSource(A::getOmitted)
+                                                       .expectOmitInDestination(AResource::getOmitted);
+    asserts.ensure();
+  }
+
+  @Test(expected = AssertionError.class)
+  public void shouldDetectExpectedSkipWhenNull() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+                                          .to(BResource.class)
+                                          .mapper();
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+                                         .to(AResource.class)
+                                         .reassign(A::getString)
+                                         .to(AResource::getAnotherString)
+                                         .replace(A::getInteger, AResource::getIntegerAsString)
+                                         .with(String::valueOf)
+                                         .omitInSource(A::getOmitted)
+                                         .omitInDestination(AResource::getOmitted)
+                                         .useMapper(bMapper)
+                                         .mapper();
+
+    AssertMapping<A, AResource> asserts = AssertMapping.of(mapper)
+                                                       .expectReassign(A::getString)
+                                                       .to(AResource::getAnotherString)
+                                                       .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                                                       .andTestButSkipWhenNull(String::valueOf)
+                                                       .expectOmitInSource(A::getOmitted)
+                                                       .expectOmitInDestination(AResource::getOmitted);
+    asserts.ensure();
+  }
+
+  @Test
+  public void shouldNotThrowAssertionError() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+                                          .to(BResource.class)
+                                          .mapper();
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+                                         .to(AResource.class)
+                                         .reassign(A::getString)
+                                         .to(AResource::getAnotherString)
+                                         .replace(A::getInteger, AResource::getIntegerAsString)
+                                         .with(String::valueOf)
+                                         .omitInSource(A::getOmitted)
+                                         .omitInDestination(AResource::getOmitted)
+                                         .useMapper(bMapper)
+                                         .mapper();
+
+    AssertMapping<A, AResource> asserts = AssertMapping.of(mapper)
+                                                       .expectReassign(A::getString)
+                                                       .to(AResource::getAnotherString)
+                                                       .expectReplace(A::getInteger, AResource::getIntegerAsString)
+                                                       .andTest(String::valueOf)
+                                                       .expectOmitInSource(A::getOmitted)
+                                                       .expectOmitInDestination(AResource::getOmitted);
+    asserts.ensure();
+  }
+}

--- a/src/test/java/com/remondis/remap/MapperTest.java
+++ b/src/test/java/com/remondis/remap/MapperTest.java
@@ -17,14 +17,14 @@ import com.remondis.remap.inheritance.ChildResource;
 
 public class MapperTest {
 
-  private static final String MORE_IN_A = "moreInA";
-  private static final Long ZAHL_IN_A = -88L;
-  private static final Integer B_INTEGER = -999;
-  private static final int B_NUMBER = 222;
-  private static final String B_STRING = "b string";
-  private static final Integer INTEGER = 310;
-  private static final int NUMBER = 210;
-  private static final String STRING = "a string";
+  public static final String MORE_IN_A = "moreInA";
+  public static final Long ZAHL_IN_A = -88L;
+  public static final Integer B_INTEGER = -999;
+  public static final int B_NUMBER = 222;
+  public static final String B_STRING = "b string";
+  public static final Integer INTEGER = 310;
+  public static final int NUMBER = 210;
+  public static final String STRING = "a string";
 
   @Test(expected = MappingException.class)
   public void shouldDenyMapNull() {

--- a/src/test/java/com/remondis/remap/assertion/A.java
+++ b/src/test/java/com/remondis/remap/assertion/A.java
@@ -1,0 +1,60 @@
+package com.remondis.remap.assertion;
+
+public class A {
+
+  private String string;
+  private B b;
+
+  private String omitted;
+
+  private Integer integer;
+
+  public A() {
+    super();
+  }
+
+  public A(String string, B b, Integer integer) {
+    super();
+    this.string = string;
+    this.b = b;
+    this.integer = integer;
+  }
+
+  public String getOmitted() {
+    return omitted;
+  }
+
+  public void setOmitted(String omitted) {
+    this.omitted = omitted;
+  }
+
+  public Integer getInteger() {
+    return integer;
+  }
+
+  public void setInteger(Integer integer) {
+    this.integer = integer;
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  public B getB() {
+    return b;
+  }
+
+  public void setB(B b) {
+    this.b = b;
+  }
+
+  @Override
+  public String toString() {
+    return "A [string=" + string + ", b=" + b + ", integer=" + integer + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/assertion/AResource.java
+++ b/src/test/java/com/remondis/remap/assertion/AResource.java
@@ -1,0 +1,60 @@
+package com.remondis.remap.assertion;
+
+public class AResource {
+
+  private String anotherString;
+  private BResource b;
+
+  private Integer omitted;
+
+  private String integerAsString;
+
+  public AResource() {
+    super();
+  }
+
+  public AResource(String anotherString, BResource b, String integerAsString) {
+    super();
+    this.anotherString = anotherString;
+    this.b = b;
+    this.integerAsString = integerAsString;
+  }
+
+  public Integer getOmitted() {
+    return omitted;
+  }
+
+  public void setOmitted(Integer omitted) {
+    this.omitted = omitted;
+  }
+
+  public String getIntegerAsString() {
+    return integerAsString;
+  }
+
+  public void setIntegerAsString(String integerAsString) {
+    this.integerAsString = integerAsString;
+  }
+
+  public String getAnotherString() {
+    return anotherString;
+  }
+
+  public void setAnotherString(String anotherString) {
+    this.anotherString = anotherString;
+  }
+
+  public BResource getB() {
+    return b;
+  }
+
+  public void setB(BResource b) {
+    this.b = b;
+  }
+
+  @Override
+  public String toString() {
+    return "AResource [anotherString=" + anotherString + ", b=" + b + ", integerAsString=" + integerAsString + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/assertion/B.java
+++ b/src/test/java/com/remondis/remap/assertion/B.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.assertion;
+
+public class B {
+
+  private String string;
+
+  public B() {
+    super();
+  }
+
+  public B(String string) {
+    super();
+    this.string = string;
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    B other = (B) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "B [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/assertion/BResource.java
+++ b/src/test/java/com/remondis/remap/assertion/BResource.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.assertion;
+
+public class BResource {
+
+  private String string;
+
+  public BResource() {
+    super();
+  }
+
+  public BResource(String string) {
+    super();
+    this.string = string;
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BResource other = (BResource) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "BResource [string=" + string + "]";
+  }
+
+}


### PR DESCRIPTION
The following features were implemented:
- Asserting the operations on a mapper
- Full compare of expected and actual mappings
- Detecting multiple asserts of the same operation
- Detecting multiple asserts of the same destination field
- Checking the expected and actual null-strategy on replace operations
- Testing of the transformation function against null input when
strategy is not skip-when-null

The following features were not implemented:
- Testing transformation functions against sample data: We cannot simply
call the transformation function with example data like a recursively
instantiated source object with primitive-default values. We do not know
if that object meets the definition of the transformation method. Plus:
The transformation test should be tested by the user including the happy
path.
