### PR TITLE
Rollback copy objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ ReMap supports
   * the declaring type has a public default constructor
   * keywords like `transient` do not have an effect on the mapping
 * circular references are currently not supported
+* mapping equal types does not copy object instances!
 * multi-classloader environments are currently not supported. All types must be loaded by the same classloader.
 
 ## How to use

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -74,20 +74,12 @@ public class ReassignTransformation extends Transformation {
       "unchecked", "rawtypes"
   })
   Object convertValue(Object sourceValue, Class<?> sourceType, Class<?> destinationType) {
-    if (isReferenceMapping(sourceType, destinationType)) {
+    if (isReferenceMapping(sourceType, destinationType) || isEqualTypes(sourceType, destinationType)) {
       return sourceValue;
     } else {
-      if (isEqualTypes(sourceType, destinationType)) {
-        // If the types are equal we can perform an identity mapping.
-        Mapper<Object, Object> mapper = (Mapper<Object, Object>) Mapping.from(sourceType)
-            .to(destinationType)
-            .mapper();
-        return mapper.map(sourceValue);
-      } else {
-        // Object types must be mapped by a registered mapper before setting the value.
-        Mapper delegateMapper = getMapperFor(sourceType, destinationType);
-        return delegateMapper.map(sourceValue);
-      }
+      // Object types must be mapped by a registered mapper before setting the value.
+      Mapper delegateMapper = getMapperFor(sourceType, destinationType);
+      return delegateMapper.map(sourceValue);
     }
   }
 

--- a/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
+++ b/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
+@Ignore
 public class CopyObjectTest {
 
   private static final String EXPECTED_STRING = "string";

--- a/src/test/java/com/remondis/remap/noBeanCopyBug/A.java
+++ b/src/test/java/com/remondis/remap/noBeanCopyBug/A.java
@@ -1,0 +1,51 @@
+package com.remondis.remap.noBeanCopyBug;
+
+import java.math.BigDecimal;
+
+public class A {
+
+  private BigDecimal bigDecimal;
+
+  public A() {
+    super();
+  }
+
+  public A(BigDecimal bigDecimal) {
+    super();
+    this.bigDecimal = bigDecimal;
+  }
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((bigDecimal == null) ? 0 : bigDecimal.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (bigDecimal == null) {
+      if (other.bigDecimal != null)
+        return false;
+    } else if (!bigDecimal.equals(other.bigDecimal))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/noBeanCopyBug/AResource.java
+++ b/src/test/java/com/remondis/remap/noBeanCopyBug/AResource.java
@@ -1,0 +1,51 @@
+package com.remondis.remap.noBeanCopyBug;
+
+import java.math.BigDecimal;
+
+public class AResource {
+
+  private BigDecimal bigDecimal;
+
+  public AResource() {
+    super();
+  }
+
+  public AResource(BigDecimal bigDecimal) {
+    super();
+    this.bigDecimal = bigDecimal;
+  }
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((bigDecimal == null) ? 0 : bigDecimal.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AResource other = (AResource) obj;
+    if (bigDecimal == null) {
+      if (other.bigDecimal != null)
+        return false;
+    } else if (!bigDecimal.equals(other.bigDecimal))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/noBeanCopyBug/NoBeanCopyBug.java
+++ b/src/test/java/com/remondis/remap/noBeanCopyBug/NoBeanCopyBug.java
@@ -1,0 +1,33 @@
+package com.remondis.remap.noBeanCopyBug;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class NoBeanCopyBug {
+
+  /**
+   * There was a bug in mapping an object holding a {@link BigDecimal}, a Java object not complying to Java bean
+   * convention. The attempt was made to copy this instance by calling a default constructor, but there is none.
+   */
+  @Test
+  public void noBeanCopyBug() {
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+        .to(AResource.class)
+        .mapper();
+
+    BigDecimal bigDecimal = new BigDecimal(1L);
+    A a = new A(bigDecimal);
+    AResource ar = mapper.map(a);
+
+    assertEquals(bigDecimal, a.getBigDecimal());
+    assertEquals(bigDecimal, ar.getBigDecimal());
+
+  }
+
+}


### PR DESCRIPTION
Rollback of the copy objects feature since this limits the reassing operations to be only valid on Java beans.