### PR TITLE
Replace andTestButSkipWhenNull(Transform) with andSkipWhenNull()

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=false
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx512m -Xms256m
-PROJECT_VERSION=1.0.4
+PROJECT_VERSION=2.0.0

--- a/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
@@ -26,7 +26,14 @@ public class ReplaceAssertBuilder<S, D, RD, RS> {
   }
 
   /**
-   * Specifies the transformation function that will be checked against null input.
+   * Expects the mapping to <b>not</b> skip the transform function on <code>null</code> input. The specified transform
+   * function will be checked against <code>null</code> input.
+   *
+   * <p>
+   * Note: This method cannot reliably check that the specified function is actually the function that was configured on
+   * the mapping. This method only verifies the skip-on-null behaviour and performs a <code>null</code> check on the
+   * specified function.
+   * </p>
    *
    * @param transformation The transformation to test.
    * @return Returns the {@link AssertMapping} for further configuration.
@@ -41,15 +48,27 @@ public class ReplaceAssertBuilder<S, D, RD, RS> {
 
   /**
    * Specifies the transform operation to be skipped when null. In this case the transformation function will not be
-   * tested. In a future release this method may allow to test the transformation function.
+   * tested.
    *
    * @param transformation The transformation function
    * @return Returns the {@link AssertMapping} for further configuration.
+   *
+   * @deprecated This method should not be used. Use {@link #andSkipWhenNull()} instead. This method will be deleted in
+   *             a future release since the expected transform function cannot be verfied.
    */
+  @Deprecated
   public AssertMapping<S, D> andTestButSkipWhenNull(Transform<RD, RS> transformation) {
-    denyNull("tranfromation", transformation);
+    return andSkipWhenNull();
+  }
+
+  /**
+   * Expects the mapping to skip the transform function on <code>null</code> input.
+   *
+   * @return Returns the {@link AssertMapping} for further configuration.
+   */
+  public AssertMapping<S, D> andSkipWhenNull() {
     ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(asserts.getMapping(),
-        sourceProperty.property, destProperty.property, transformation, true);
+        sourceProperty.property, destProperty.property, null, true);
     asserts.addAssertion(replace);
     return asserts;
   }

--- a/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
@@ -47,21 +47,6 @@ public class ReplaceAssertBuilder<S, D, RD, RS> {
   }
 
   /**
-   * Specifies the transform operation to be skipped when null. In this case the transformation function will not be
-   * tested.
-   *
-   * @param transformation The transformation function
-   * @return Returns the {@link AssertMapping} for further configuration.
-   *
-   * @deprecated This method should not be used. Use {@link #andSkipWhenNull()} instead. This method will be deleted in
-   *             a future release since the expected transform function cannot be verified.
-   */
-  @Deprecated
-  public AssertMapping<S, D> andTestButSkipWhenNull(Transform<RD, RS> transformation) {
-    return andSkipWhenNull();
-  }
-
-  /**
    * Expects the mapping to skip the transform function on <code>null</code> input.
    *
    * @return Returns the {@link AssertMapping} for further configuration.

--- a/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
@@ -38,14 +38,14 @@ public class ReplaceAssertBuilder<S, D, RD, RS> {
    * @param transformation The transformation to test.
    * @return Returns the {@link AssertMapping} for further configuration.
    */
-  public AssertMapping<S, D> andTest(Transform<RD, RS> transformation) {
+  public AssertMapping<S, D> andTest(Transform<RS, RD> transformation) {
     denyNull("tranfromation", transformation);
-    ReplaceTransformation<RD, RS> replace = new ReplaceTransformation<RD, RS>(asserts.getMapping(),
-        sourceProperty.property, destProperty.property, transformation, false);
+    ReplaceTransformation<RS, RD> replace = new ReplaceTransformation<>(asserts.getMapping(), sourceProperty.property,
+        destProperty.property, transformation, false);
     asserts.addAssertion(replace);
     return asserts;
   }
- 
+
   /**
    * Expects the mapping to skip the transform function on <code>null</code> input.
    *

--- a/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReplaceAssertBuilder.java
@@ -54,7 +54,7 @@ public class ReplaceAssertBuilder<S, D, RD, RS> {
    * @return Returns the {@link AssertMapping} for further configuration.
    *
    * @deprecated This method should not be used. Use {@link #andSkipWhenNull()} instead. This method will be deleted in
-   *             a future release since the expected transform function cannot be verfied.
+   *             a future release since the expected transform function cannot be verified.
    */
   @Deprecated
   public AssertMapping<S, D> andTestButSkipWhenNull(Transform<RD, RS> transformation) {

--- a/src/test/java/com/remondis/remap/AssertMappingTest.java
+++ b/src/test/java/com/remondis/remap/AssertMappingTest.java
@@ -295,13 +295,13 @@ public class AssertMappingTest {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(A::getInteger, AResource::getIntegerAsString)
-          .andTestButSkipWhenNull(String::valueOf)
+          .andSkipWhenNull()
           .expectReassign(A::getString)
           .to(AResource::getAnotherString)
           .expectOmitInSource(A::getOmitted)
           .expectOmitInDestination(AResource::getOmitted)
           .expectReplace(A::getInteger, AResource::getIntegerAsString)
-          .andTestButSkipWhenNull(String::valueOf)
+          .andSkipWhenNull()
           .ensure();
     }).isInstanceOf(AssertionError.class)
         .hasMessage(TRANSFORMATION_ALREADY_ADDED)
@@ -317,7 +317,7 @@ public class AssertMappingTest {
           .expectOmitInSource(A::getOmitted)
           .expectOmitInDestination(AResource::getOmitted)
           .expectReplace(A::getInteger, AResource::getIntegerAsString)
-          .andTestButSkipWhenNull(String::valueOf)
+          .andSkipWhenNull()
           .ensure();
     }).isInstanceOf(AssertionError.class)
         .hasMessage(TRANSFORMATION_ALREADY_ADDED)
@@ -327,7 +327,7 @@ public class AssertMappingTest {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(A::getInteger, AResource::getIntegerAsString)
-          .andTestButSkipWhenNull(String::valueOf)
+          .andSkipWhenNull()
           .expectReassign(A::getString)
           .to(AResource::getAnotherString)
           .expectOmitInSource(A::getOmitted)
@@ -389,7 +389,7 @@ public class AssertMappingTest {
         .expectReassign(A::getString)
         .to(AResource::getAnotherString)
         .expectReplace(A::getInteger, AResource::getIntegerAsString)
-        .andTestButSkipWhenNull(String::valueOf)
+        .andSkipWhenNull()
         .expectOmitInSource(A::getOmitted)
         .expectOmitInDestination(AResource::getOmitted);
     asserts.ensure();

--- a/src/test/java/com/remondis/remap/demo/DemoTest.java
+++ b/src/test/java/com/remondis/remap/demo/DemoTest.java
@@ -33,7 +33,7 @@ public class DemoTest {
         .to(Person::getSalutation)
         // A customer has a gender as string, person uses a gender enumeration
         .expectReplace(Customer::getGender, Person::getGender)
-        .andTestButSkipWhenNull(Gender::valueOf)
+        .andSkipWhenNull()
         .ensure();
   }
 }


### PR DESCRIPTION
The old function was designed to verify the specified transformation function but this is not reliably possible. This feature was never implemented and therefore removed.