### PR TITLE
Add automatic module name to manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,15 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
+jar {
+    manifest {
+        name = "remap"
+        instruction "Bundle-Vendor", "REMONDIS IT Services GmbH & Co. KG"
+        instruction "Bundle-DocURL", "https://github.com/remondis-it/remap"
+        instruction "Automatic-Module-Name", "com.remondis.remap"
+    }
+}
+
 
 if (project.hasProperty('release')) {
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,10 +76,9 @@ artifacts {
 
 jar {
     manifest {
-        name = "remap"
-        instruction "Bundle-Vendor", "REMONDIS IT Services GmbH & Co. KG"
-        instruction "Bundle-DocURL", "https://github.com/remondis-it/remap"
-        instruction "Automatic-Module-Name", "com.remondis.remap"
+         attributes("Bundle-Vendor": "REMONDIS IT Services GmbH & Co. KG",
+                    "Bundle-DocURL": "https://github.com/remondis-it/remap",
+                    "Automatic-Module-Name": "com.remondis.remap")
     }
 }
 


### PR DESCRIPTION
This makes ReMap forward compatible to Java 9.