### PR TITLE
Bug fix for Boolean property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=false
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx512m -Xms256m
-PROJECT_VERSION=3.0.3
+PROJECT_VERSION=3.0.4

--- a/src/main/java/com/remondis/remap/ReflectionUtil.java
+++ b/src/main/java/com/remondis/remap/ReflectionUtil.java
@@ -149,7 +149,8 @@ class ReflectionUtil {
   }
 
   static boolean isBool(Class<?> type) {
-    return type == Boolean.TYPE || type == Boolean.class;
+    // isBool is used to determine if "is"-method should be used. This is only the case for primitive type.
+    return type == Boolean.TYPE;
   }
 
   static boolean hasArguments(Method method) {

--- a/src/test/java/com/remondis/remap/possibleBug/A.java
+++ b/src/test/java/com/remondis/remap/possibleBug/A.java
@@ -1,0 +1,26 @@
+package com.remondis.remap.possibleBug;
+
+public class A {
+  private Boolean newsletterSubscribed;
+  private String mail;
+
+  public A() {
+    super();
+  }
+
+  public String getMail() {
+    return mail;
+  }
+
+  public void setMail(String mail) {
+    this.mail = mail;
+  }
+
+  public Boolean getNewsletterSubscribed() {
+    return newsletterSubscribed;
+  }
+
+  public void setNewsletterSubscribed(Boolean newsletterSubscribed) {
+    this.newsletterSubscribed = newsletterSubscribed;
+  }
+}

--- a/src/test/java/com/remondis/remap/possibleBug/B.java
+++ b/src/test/java/com/remondis/remap/possibleBug/B.java
@@ -1,0 +1,18 @@
+package com.remondis.remap.possibleBug;
+
+public class B {
+  private String email;
+
+  public B() {
+    super();
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/possibleBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/possibleBug/MapperTest.java
@@ -1,0 +1,18 @@
+package com.remondis.remap.possibleBug;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapping;
+
+public class MapperTest {
+
+  @Test
+  public void shouldMap() {
+    Mapping.from(A.class)
+        .to(B.class)
+        .reassign(A::getMail)
+        .to(B::getEmail)
+        .omitInSource(A::getNewsletterSubscribed)
+        .mapper();
+  }
+}


### PR DESCRIPTION

- Fixed `com.remondis.remap.ReflectionUtil.isBool(Class<?>)`: `isXXX()`-methods are only required for the primitive boolean. Properties of type `java.lang.Boolean` are accessed using `getXXX()`.
- Regression JUnit test added