### PR TITLE
Revert "Use instance to map"

### DIFF
--- a/src/main/java/com/remondis/remap/Mapper.java
+++ b/src/main/java/com/remondis/remap/Mapper.java
@@ -40,18 +40,6 @@ public class Mapper<S, D> {
   }
 
   /**
-   * Performs the mapping from the source into a specified destination object while overwriting fields in the
-   * destination object if affected by the mapping configuration.
-   *
-   * @param source The source object to map to a new destination object.
-   * @param destination The destination object to map into. Field affected by the mapping will be overwritten.
-   * @return Returns the specified destination object.
-   */
-  public <Source extends S> D map(Source source, D destination) {
-    return mapping.map(source, destination);
-  }
-
-  /**
    * Performs the mapping for the specified {@link Collection}.
    *
    * @param source The source collection to map to a new collection of destination objects.

--- a/src/main/java/com/remondis/remap/Mapping.java
+++ b/src/main/java/com/remondis/remap/Mapping.java
@@ -495,26 +495,10 @@ public final class Mapping<S, D> {
    * @return Returns a newly created destination object.
    */
   D map(S source) {
-    return map(source, null);
-  }
-
-  /**
-   * Performs the actual mapping with iteration recursively through the object hierarchy.
-   *
-   * @param source
-   *        The source object to map to a new destination object.
-   * @param destination
-   *        The destination object to populate
-   * @return Returns a newly created destination object.
-   */
-  D map(S source, D destination) {
-    D destinationObject = destination;
     if (source == null) {
       throw MappingException.denyMappingOfNull();
     }
-    if (destination == null) {
-      destinationObject = createDestination();
-    }
+    D destinationObject = createDestination();
     for (Transformation t : mappings) {
       t.performTransformation(source, destinationObject);
     }

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -43,9 +43,9 @@ public class ReassignTransformation extends Transformation {
       if (isCollection(sourceType)) {
         Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod());
         Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod());
-        destinationValue = convertCollection(sourceValue, sourceCollectionType, destination, destinationCollectionType);
+        destinationValue = convertCollection(sourceValue, sourceCollectionType, destinationCollectionType);
       } else {
-        destinationValue = convertValue(sourceValue, sourceType, destination, destinationType);
+        destinationValue = convertValue(sourceValue, sourceType, destinationType);
       }
 
       writeOrFail(destinationProperty, destination, destinationValue);
@@ -56,15 +56,15 @@ public class ReassignTransformation extends Transformation {
       "unchecked", "rawtypes"
   })
   private Object convertCollection(Object sourceValue, Class<?> sourceCollectionType,
-                                   Object destinationValue, Class<?> destinationCollectionType) {
+      Class<?> destinationCollectionType) {
     Collection collection = Collection.class.cast(sourceValue);
     Collector collector = getCollector(collection);
     return collection.stream()
         .map(o -> {
           if (isCollection(o)) {
-            return convertCollection(o, sourceCollectionType, destinationValue, destinationCollectionType);
+            return convertCollection(o, sourceCollectionType, destinationCollectionType);
           } else {
-            return convertValue(o, sourceCollectionType, destinationValue, destinationCollectionType);
+            return convertValue(o, sourceCollectionType, destinationCollectionType);
           }
         })
         .collect(collector);
@@ -73,14 +73,13 @@ public class ReassignTransformation extends Transformation {
   @SuppressWarnings({
       "unchecked", "rawtypes"
   })
-  Object convertValue(Object sourceValue, Class<?> sourceType, Object destinationValue, Class<?> destinationType) {
+  Object convertValue(Object sourceValue, Class<?> sourceType, Class<?> destinationType) {
     if (isReferenceMapping(sourceType, destinationType) || isEqualTypes(sourceType, destinationType)) {
       return sourceValue;
     } else {
       // Object types must be mapped by a registered mapper before setting the value.
       Mapper delegateMapper = getMapperFor(sourceType, destinationType);
-      Object destinationValueMapped = readOrFail(destinationProperty, destinationValue);
-      return delegateMapper.map(sourceValue, destinationValueMapped);
+      return delegateMapper.map(sourceValue);
     }
   }
 

--- a/src/test/java/com/remondis/remap/A.java
+++ b/src/test/java/com/remondis/remap/A.java
@@ -6,6 +6,7 @@ public class A {
   private String string;
   private int number;
   private Integer integer;
+
   private Long zahlInA;
   private B b;
 

--- a/src/test/java/com/remondis/remap/AResource.java
+++ b/src/test/java/com/remondis/remap/AResource.java
@@ -3,6 +3,7 @@ package com.remondis.remap;
 public class AResource {
 
   private String moreInAResource;
+
   private String string;
   private int number;
   private Integer integer;
@@ -17,15 +18,6 @@ public class AResource {
     super();
     this.string = string;
     this.integer = integer;
-    this.b = b;
-  }
-
-  public AResource(String moreInAResource, String string, int number, Integer integer, Long zahlInAResource, BResource b) {
-    this.moreInAResource = moreInAResource;
-    this.string = string;
-    this.number = number;
-    this.integer = integer;
-    this.zahlInAResource = zahlInAResource;
     this.b = b;
   }
 

--- a/src/test/java/com/remondis/remap/MapperTest.java
+++ b/src/test/java/com/remondis/remap/MapperTest.java
@@ -128,53 +128,6 @@ public class MapperTest {
   }
 
   /**
-   * Ensures that the {@link Mapper} use the instance and the nested instance
-   */
-  @Test
-  public void shouldMapInstantiatedObject() {
-    Mapper<A, AResource> mapper = Mapping.from(A.class)
-            .to(AResource.class)
-            .reassign(A::getMoreInA)
-            .to(AResource::getMoreInAResource)
-            .reassign(A::getZahlInA)
-            .to(AResource::getZahlInAResource)
-            .useMapper(Mapping.from(B.class)
-                    .to(BResource.class)
-                    .mapper())
-            .mapper();
-
-    int bNumberNew = 123;
-    String aStringNew = "abc";
-    int aNumberNew = 456;
-    B b = new B(null, bNumberNew, null);
-    A a = new A(null, aStringNew, aNumberNew, null, null, b);
-
-    BResource bResource = new BResource(B_STRING, B_NUMBER, B_INTEGER);
-    AResource aResource = new AResource(MORE_IN_A, STRING, NUMBER, INTEGER, ZAHL_IN_A, bResource);
-
-    AResource ar = mapper.map(a, aResource);
-
-    assertEquals(null, a.getMoreInA());
-    assertEquals(MORE_IN_A, ar.getMoreInAResource());
-    assertEquals(aStringNew, a.getString());
-    assertEquals(aStringNew, ar.getString());
-    assertEquals(aNumberNew, a.getNumber());
-    assertEquals(aNumberNew, ar.getNumber());
-    assertEquals(null, a.getInteger());
-    assertEquals(INTEGER, ar.getInteger());
-    assertEquals(null, a.getZahlInA());
-    assertEquals(ZAHL_IN_A, ar.getZahlInAResource());
-
-    BResource br = ar.getB();
-    assertEquals(null, b.getString());
-    assertEquals(B_STRING, br.getString());
-    assertEquals(bNumberNew, b.getNumber());
-    assertEquals(bNumberNew, br.getNumber());
-    assertEquals(null, b.getInteger());
-    assertEquals(B_INTEGER, br.getInteger());
-  }
-
-  /**
    * Ensures that the {@link Mapper} detects one more property in the source object that is not omitted by the mapping
    * configuration. The {@link Mapper} is expected to throw a {@link MappingException}.
    */


### PR DESCRIPTION
Reverts remondis-it/remap#39

Revert was required because the nested mappings are not supported.