### PR TITLE
Support wrapper classes

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
-  <local-check-config name="ReMap Checkstyle" location="internal_config_1523276071813.xml" type="internal" description=""/>
-  <fileset name="all" enabled="true" check-config-name="ReMap Checkstyle" local="true">
-    <file-match-pattern match-pattern="src/main" include-pattern="true"/>
+  <local-check-config name="ReMap" location="C:\Users\cschu\git\remap\shared\config\checkstyle\checkstyle.xml" type="external" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <fileset name="Src Main" enabled="true" check-config-name="ReMap" local="true">
+    <file-match-pattern match-pattern="src/main/java" include-pattern="true"/>
   </fileset>
 </fileset-config>

--- a/src/main/java/com/remondis/remap/Mapper.java
+++ b/src/main/java/com/remondis/remap/Mapper.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * This is the default implementation for a {@link Mapper}.
+ * This class defines a reusable mapper object to perform multiple mappings for the configured object types.
  *
  * @param <S> The source type
  * @param <D> The destination type

--- a/src/main/java/com/remondis/remap/Mapper.java
+++ b/src/main/java/com/remondis/remap/Mapper.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * This class defines a reusable mapper object to perform multiple mappings for the configured object types.
+ * This is the default implementation for a {@link Mapper}.
  *
  * @param <S> The source type
  * @param <D> The destination type
@@ -20,12 +20,12 @@ public class Mapper<S, D> {
 
   private Mapping<S, D> mapping;
 
-  Mapper(Mapping<S, D> mapping) {
+  public Mapper(Mapping<S, D> mapping) {
     super();
     this.mapping = mapping;
   }
 
-  Mapping<S, D> getMapping() {
+  public final Mapping<S, D> getMapping() {
     return mapping;
   }
 
@@ -35,7 +35,7 @@ public class Mapper<S, D> {
    * @param source The source object to map to a new destination object.
    * @return Returns a newly created destination object.
    */
-  public <Source extends S> D map(Source source) {
+  public final <Source extends S> D map(Source source) {
     return mapping.map(source);
   }
 
@@ -47,7 +47,7 @@ public class Mapper<S, D> {
    * @param destination The destination object to map into. Field affected by the mapping will be overwritten.
    * @return Returns the specified destination object.
    */
-  public <Source extends S> D map(Source source, D destination) {
+  public final <Source extends S> D map(Source source, D destination) {
     return mapping.map(source, destination);
   }
 
@@ -58,7 +58,7 @@ public class Mapper<S, D> {
    * @return Returns a newly created collection of destination objects. The type of the resulting collection is either
    *         {@link List} or {@link Set} depending on the specified type.
    */
-  public Collection<D> map(Collection<? extends S> source) {
+  public final Collection<D> map(Collection<? extends S> source) {
     return _mapCollection(source);
   }
 
@@ -68,7 +68,7 @@ public class Mapper<S, D> {
    * @param source The source collection to map to a new collection of destination objects.
    * @return Returns a newly created list of destination objects.
    */
-  public List<D> map(List<? extends S> source) {
+  public final List<D> map(List<? extends S> source) {
     return (List<D>) _mapCollection(source);
   }
 
@@ -78,7 +78,7 @@ public class Mapper<S, D> {
    * @param source The source collection to map to a new collection of destination objects.
    * @return Returns a newly set list of destination objects.
    */
-  public Set<D> map(Set<? extends S> source) {
+  public final Set<D> map(Set<? extends S> source) {
     return (Set<D>) _mapCollection(source);
   }
 
@@ -88,14 +88,14 @@ public class Mapper<S, D> {
    * @param iterable The source iterable to be mapped to a new {@link List} of destination objects.
    * @return Returns a newly set list of destination objects.
    */
-  public List<D> map(Iterable<? extends S> iterable) {
+  public final List<D> map(Iterable<? extends S> iterable) {
     Stream<? extends S> stream = StreamSupport.stream(iterable.spliterator(), false);
     return stream.map(this::map)
         .collect(Collectors.toList());
   }
 
   @SuppressWarnings("unchecked")
-  private Collection<D> _mapCollection(Collection<? extends S> source) {
+  private final Collection<D> _mapCollection(Collection<? extends S> source) {
     return (Collection<D>) source.stream()
         .map(this::map)
         .collect(getCollector(source));

--- a/src/main/java/com/remondis/remap/Mapping.java
+++ b/src/main/java/com/remondis/remap/Mapping.java
@@ -9,6 +9,7 @@ import static com.remondis.remap.Properties.createUnmappedMessage;
 import static com.remondis.remap.ReflectionUtil.newInstance;
 
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -276,6 +277,19 @@ public final class Mapping<S, D> {
     addStrictMapping();
     validateMapping();
     return new Mapper<>(this);
+  }
+
+  public final <W extends Mapper<S, D>> W mapper(Class<W> wrapperType) {
+    addStrictMapping();
+    validateMapping();
+    try {
+      return wrapperType.getConstructor(Mapping.class)
+          .newInstance(this);
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+        | NoSuchMethodException | SecurityException e) {
+      throw new MappingException(
+          "Cannot wrap mapper - please make sure the specified wrapper class extends com.remondis.remap.Mapper.");
+    }
   }
 
   /**

--- a/src/main/java/com/remondis/remap/Mapping.java
+++ b/src/main/java/com/remondis/remap/Mapping.java
@@ -279,6 +279,14 @@ public final class Mapping<S, D> {
     return new Mapper<>(this);
   }
 
+  /**
+   * Wraps the mapper instance using the specified wrapper type. Valid wrapper types are classes that extend
+   * {@link Mapper}. Wrapper classes can be used to reference custom types instead of referencing the generic
+   * parameterized {@link Mapper}.
+   * 
+   * @param wrapperType The wrapper type. <b>Note: Wrapper types are custom types that extend {@link Mapper}.</b>
+   * @return Returns the mapper instance as the specified wrapper type.
+   */
   public final <W extends Mapper<S, D>> W mapper(Class<W> wrapperType) {
     addStrictMapping();
     validateMapping();

--- a/src/test/java/com/remondis/remap/wrapperclass/Customer.java
+++ b/src/test/java/com/remondis/remap/wrapperclass/Customer.java
@@ -1,0 +1,19 @@
+package com.remondis.remap.wrapperclass;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class Customer {
+
+  private String title;
+  private String forname;
+  private String name;
+  private String gender;
+  private String address;
+}

--- a/src/test/java/com/remondis/remap/wrapperclass/DemoTest.java
+++ b/src/test/java/com/remondis/remap/wrapperclass/DemoTest.java
@@ -1,0 +1,38 @@
+package com.remondis.remap.wrapperclass;
+
+import org.junit.Test;
+
+import com.remondis.remap.AssertMapping;
+import com.remondis.remap.Mapping;
+
+public class DemoTest {
+  @Test
+  public void demoMapping() {
+    MyMapper customerPersonMapper = Mapping.from(Customer.class)
+        .to(Person.class)
+        // A customer has an address, a person might have no address
+        .omitInSource(Customer::getAddress)
+        // A person has a body height that is not available for a customer
+        .omitInDestination(Person::getBodyHeight)
+        // A customer has a titles aka. salutation that maps to a persons salutation.
+        .reassign(Customer::getTitle)
+        .to(Person::getSalutation)
+        // A customer has a gender as string, person uses a gender enumeration
+        .replace(Customer::getGender, Person::getGender)
+        .withSkipWhenNull(Gender::valueOf)
+        .mapper(MyMapper.class);
+
+    AssertMapping.of(customerPersonMapper)
+        // A customer has an address, a person might have no address
+        .expectOmitInSource(Customer::getAddress)
+        // A person has a body height that is not available for a customer
+        .expectOmitInDestination(Person::getBodyHeight)
+        // A customer has a titles aka. salutation that maps to a persons salutation.
+        .expectReassign(Customer::getTitle)
+        .to(Person::getSalutation)
+        // A customer has a gender as string, person uses a gender enumeration
+        .expectReplace(Customer::getGender, Person::getGender)
+        .andSkipWhenNull()
+        .ensure();
+  }
+}

--- a/src/test/java/com/remondis/remap/wrapperclass/Gender.java
+++ b/src/test/java/com/remondis/remap/wrapperclass/Gender.java
@@ -1,0 +1,6 @@
+package com.remondis.remap.wrapperclass;
+
+public enum Gender {
+  MALE,
+  FEMALE;
+}

--- a/src/test/java/com/remondis/remap/wrapperclass/MyMapper.java
+++ b/src/test/java/com/remondis/remap/wrapperclass/MyMapper.java
@@ -1,0 +1,11 @@
+package com.remondis.remap.wrapperclass;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class MyMapper extends Mapper<Customer, Person> {
+
+  public MyMapper(Mapping<Customer, Person> mapping) {
+    super(mapping);
+  }
+}

--- a/src/test/java/com/remondis/remap/wrapperclass/Person.java
+++ b/src/test/java/com/remondis/remap/wrapperclass/Person.java
@@ -1,0 +1,19 @@
+package com.remondis.remap.wrapperclass;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class Person {
+
+  private String salutation;
+  private String forname;
+  private String name;
+  private Gender gender;
+  private double bodyHeight;
+}


### PR DESCRIPTION
I large projects (especially when using CDI) it can be confusing to find the right mapper factory/configuration class for a reference like `Mapper<S,D> someMapper`. It would be more transparent if custom types could be used for CDI like `MyMapper myMapper`. To support this, a minor API extension was added.

Users can now specify a custom type for mapper instances.