### PR TITLE
Relax the type restriction for reassing operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ ReMap is a library that simplifies conversion of objects field by field and grea
 <dependency>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>3.0.2</version>
+    <version>4.0.3</version>
 </dependency>
 ```
 
-...or in Gradle using `compile "com.remondis:remap:3.0.2"`.
+...or in Gradle using `compile "com.remondis:remap:4.0.3"`.
 
 The following code snippet shows how to map a source type to a destination type:
 
@@ -61,14 +61,16 @@ You can find this demo and the involved classes [here](src/test/java/com/remondi
 
 ReMap is a library that simplifies conversion of objects field by field. It was developed to make conversion of database entities to DTOs (data transfer objects) easier. The use of ReMap makes converter classes and unit tests for converters obsolete: ReMap only needs a specification of what fields are to be mapped, but the amount of code that actually performs the assignments and transformations is minimized. Therefore the code that must be unit-tested is also minimized.
 
-ReMap maps a objects of a source to a destination type. As per default ReMap tries to map all fields from the source to the destination object if the fields have equal name and type. __Only differences between the source type and the target type must be specified when creating a mapper.__
+ReMap maps a objects of a source to a destination type. As per default ReMap tries to map all fields from the source to the destination object if the fields have equal name and equal types or equal name and a mapper was registered to perform the type mapping. __Only differences between the source type and the target type must be specified when creating a mapper.__
 
 ## Mapping operations
 
 The following operations can be declared on a mapper:
 * `omitInSource`: omits a field in the source type and skips the mapping.
 * `omitInDestination`: omits a field in the destination type and skips the mapping.
-* `reassign`: maps a source field to the destination field of the same type while changing the field name.
+* `reassign`: maps a source field to the destination field
+	* if the property types are equal, references are copied
+	* if the property types differ, a mapper must be registered that supports the type mapping
 * `replace`: converts a source field to the destination field while changing the field name and the type. To transform the source object into the destination type a transformation function is to be specified.
 * `replaceCollection`: converts a source collection to the destination collection by applying a transform function elementwise.
 * `set`: Sets a value provided either by a function or by a value supplier in the destination.

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 									<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
 									<message>No Snapshots Allowed!</message>
 									<excludes>
-										<!-- We want to exclude child module dependencies from this check, 
+										<!-- We want to exclude child module dependencies from this check,
 											as we're always using SNAPSHOT versions (except when performing a release) -->
 										<exclude>${project.groupId}:*</exclude>
 									</excludes>

--- a/src/main/java/com/remondis/remap/Mapping.java
+++ b/src/main/java/com/remondis/remap/Mapping.java
@@ -152,12 +152,11 @@ public final class Mapping<S, D> {
    *        invocation.
    * @return Returns a {@link ReassignBuilder} to specify the destination field.
    */
-  public <RS> ReassignBuilder<S, D, RS> reassign(TypedSelector<RS, S> sourceSelector) {
+  public <RS> ReassignBuilder<S, D> reassign(FieldSelector<S> sourceSelector) {
     denyNull("sourceSelector", sourceSelector);
-
-    TypedPropertyDescriptor<RS> typedSourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReassignBuilder.ASSIGN, this.source, sourceSelector);
-    ReassignBuilder<S, D, RS> reassignBuilder = new ReassignBuilder<>(typedSourceProperty, destination, this);
+    PropertyDescriptor typedSourceProperty = getPropertyFromFieldSelector(Target.SOURCE, ReassignBuilder.ASSIGN,
+        this.source, sourceSelector);
+    ReassignBuilder<S, D> reassignBuilder = new ReassignBuilder<>(typedSourceProperty, destination, this);
     return reassignBuilder;
   }
 

--- a/src/main/java/com/remondis/remap/ReassignBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignBuilder.java
@@ -1,7 +1,7 @@
 package com.remondis.remap;
 
 import static com.remondis.remap.Lang.denyNull;
-import static com.remondis.remap.Mapping.getTypedPropertyFromFieldSelector;
+import static com.remondis.remap.Mapping.getPropertyFromFieldSelector;
 
 import java.beans.PropertyDescriptor;
 
@@ -10,21 +10,20 @@ import java.beans.PropertyDescriptor;
  *
  * @param <S> The source type.
  * @param <D> The destination type.
- * @param <RS> The source field type.
  */
-public class ReassignBuilder<S, D, RS> {
+public class ReassignBuilder<S, D> {
 
   static final String ASSIGN = "assign";
 
-  private TypedPropertyDescriptor<RS> typedSourceProperty;
+  private PropertyDescriptor sourceProperty;
 
   private Mapping<S, D> mapping;
 
   private Class<D> destination;
 
-  ReassignBuilder(TypedPropertyDescriptor<RS> typedSourceProperty, Class<D> destination, Mapping<S, D> mapping) {
+  ReassignBuilder(PropertyDescriptor sourceProperty, Class<D> destination, Mapping<S, D> mapping) {
     super();
-    this.typedSourceProperty = typedSourceProperty;
+    this.sourceProperty = sourceProperty;
     this.mapping = mapping;
     this.destination = destination;
   }
@@ -37,14 +36,12 @@ public class ReassignBuilder<S, D, RS> {
    *
    * @return Returns the {@link Mapping} for further mapping configuration.
    */
-  public Mapping<S, D> to(TypedSelector<RS, D> destinationSelector) {
+  public Mapping<S, D> to(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
-    TypedPropertyDescriptor<RS> typedDestProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, ASSIGN,
-        destination, destinationSelector);
-    PropertyDescriptor sourceProperty = typedSourceProperty.property;
-    PropertyDescriptor destinationProperty = typedDestProperty.property;
-    ReassignTransformation transformation = new ReassignTransformation(mapping, sourceProperty, destinationProperty);
-    mapping.addMapping(sourceProperty, destinationProperty, transformation);
+    PropertyDescriptor destProperty = getPropertyFromFieldSelector(Target.DESTINATION, ASSIGN, destination,
+        destinationSelector);
+    ReassignTransformation transformation = new ReassignTransformation(mapping, sourceProperty, destProperty);
+    mapping.addMapping(sourceProperty, destProperty, transformation);
     return mapping;
   }
 

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/A.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/A.java
@@ -1,0 +1,36 @@
+package com.remondis.remap.implicitMappings.differentFieldNames;
+
+import java.util.List;
+
+public class A {
+
+  private B b;
+  private List<B> bs;
+
+  public A() {
+    super();
+  }
+
+  public A(B b, List<B> bs) {
+    super();
+    this.b = b;
+    this.bs = bs;
+  }
+
+  public B getB() {
+    return b;
+  }
+
+  public void setB(B b) {
+    this.b = b;
+  }
+
+  public List<B> getBs() {
+    return bs;
+  }
+
+  public void setBs(List<B> bs) {
+    this.bs = bs;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/AResource.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/AResource.java
@@ -1,0 +1,36 @@
+package com.remondis.remap.implicitMappings.differentFieldNames;
+
+import java.util.List;
+
+public class AResource {
+
+  private BResource bResource;
+  private List<BResource> bResources;
+
+  public AResource() {
+    super();
+  }
+
+  public AResource(BResource bResource, List<BResource> bResources) {
+    super();
+    this.bResource = bResource;
+    this.bResources = bResources;
+  }
+
+  public BResource getbResource() {
+    return bResource;
+  }
+
+  public void setbResource(BResource bResource) {
+    this.bResource = bResource;
+  }
+
+  public List<BResource> getbResources() {
+    return bResources;
+  }
+
+  public void setbResources(List<BResource> bResources) {
+    this.bResources = bResources;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/B.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/B.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.implicitMappings.differentFieldNames;
+
+public class B {
+
+  private String string;
+
+  public B(String string) {
+    super();
+    this.string = string;
+  }
+
+  public B() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/BResource.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/BResource.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.implicitMappings.differentFieldNames;
+
+public class BResource {
+
+  private String anotherString;
+
+  public BResource(String string) {
+    super();
+    this.anotherString = string;
+  }
+
+  public BResource() {
+    super();
+  }
+
+  public String getAnotherString() {
+    return anotherString;
+  }
+
+  public void setAnotherString(String anotherString) {
+    this.anotherString = anotherString;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
@@ -1,4 +1,4 @@
-package com.remondis.remap.implicitMappings.sameFieldNames;
+package com.remondis.remap.implicitMappings.differentFieldNames;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -18,6 +18,7 @@ import com.remondis.remap.Mapping;
  * mapper was registered that maps type(b) -> type(b') ].
  */
 public class ImplicitMappingTest {
+
   private Mapper<A, AResource> aMapper;
 
   @Before
@@ -29,6 +30,10 @@ public class ImplicitMappingTest {
         .mapper();
     this.aMapper = Mapping.from(A.class)
         .to(AResource.class)
+        .reassign(A::getB)
+        .to(AResource::getbResource)
+        .reassign(A::getBs)
+        .to(AResource::getbResources)
         .useMapper(bMapper)
         .mapper();
   }
@@ -36,15 +41,15 @@ public class ImplicitMappingTest {
   @Test
   public void mappingImplicitNullValues() {
     AResource aResource = aMapper.map(new A(null, null));
-    assertNull(aResource.getB());
+    assertNull(aResource.getbResource());
   }
 
   @Test
   public void mappingImplicit() {
     AResource aResource = aMapper
         .map(new A(new B("string"), asList(new B("string"), new B("string1"), new B("string2"))));
-    assertNotNull(aResource.getB());
-    List<BResource> bs = aResource.getBs();
+    assertNotNull(aResource.getbResource());
+    List<BResource> bs = aResource.getbResources();
     assertNotNull(bs);
     assertEquals(3, bs.size());
   }


### PR DESCRIPTION
It is now possible to use registered mappers for reassing operations.