### PR TITLE
Updated CGLIB and ASM Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,14 +271,19 @@
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
-
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-			<version>3.2.6</version>
-			<scope>compile</scope>
-		</dependency>
-
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>3.2.9</version>
+            <scope>compile</scope>
+            <!-- Exclusion needed due to bug in cglib POM. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>


### PR DESCRIPTION
- ANT excluded from pom due to bug in cglib POM.
- See #72 