### PR TITLE
Rassign and implicit mapping of maps is unsupported

### DIFF
--- a/src/test/java/com/remondis/remap/maps/reassignMaps/A.java
+++ b/src/test/java/com/remondis/remap/maps/reassignMaps/A.java
@@ -1,0 +1,22 @@
+package com.remondis.remap.maps.reassignMaps;
+
+import java.util.Map;
+
+public class A {
+
+  private Map<String, String> map;
+
+  public A() {
+    super();
+
+  }
+
+  public Map<String, String> getMap() {
+    return map;
+  }
+
+  public void setMap(Map<String, String> map) {
+    this.map = map;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/reassignMaps/AResource.java
+++ b/src/test/java/com/remondis/remap/maps/reassignMaps/AResource.java
@@ -1,0 +1,22 @@
+package com.remondis.remap.maps.reassignMaps;
+
+import java.util.Map;
+
+public class AResource {
+
+  private Map<String, String> map;
+
+  public AResource() {
+    super();
+
+  }
+
+  public Map<String, String> getMap() {
+    return map;
+  }
+
+  public void setMap(Map<String, String> map) {
+    this.map = map;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/reassignMaps/MapperTest.java
+++ b/src/test/java/com/remondis/remap/maps/reassignMaps/MapperTest.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.maps.reassignMaps;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.TypeMapping;
+
+public class MapperTest {
+
+  @Test
+  public void shouldReassingMapsWithTypeMapping() {
+    Mapper<A, AResource> mapper = Mapping.from(A.class)
+        .to(AResource.class)
+        .useMapper(TypeMapping.from(Map.class)
+            .to(Map.class)
+            .applying(m -> new HashMap<>(m)))
+        .mapper();
+
+  }
+}


### PR DESCRIPTION
- Even if a type mapping is specified, the mapping of maps is
restricted.

com.remondis.remap.maps.reassignMaps.MapperTest demonstrates the
restriction.