### PR TITLE
Omitting source properties breaks implicit mappings

### DIFF
--- a/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/A.java
+++ b/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/A.java
@@ -1,0 +1,45 @@
+package com.remondis.remap.regression.omitOthersOmitsImplicitMappings;
+
+public class A {
+
+  private String string1;
+  private String string2;
+  private String anotherString;
+
+  public A(String string1, String string2, String anotherString) {
+    super();
+    this.string1 = string1;
+    this.string2 = string2;
+    this.anotherString = anotherString;
+  }
+
+  public A() {
+    super();
+    // TODO Auto-generated constructor stub
+  }
+
+  public String getString1() {
+    return string1;
+  }
+
+  public void setString1(String string1) {
+    this.string1 = string1;
+  }
+
+  public String getString2() {
+    return string2;
+  }
+
+  public void setString2(String string2) {
+    this.string2 = string2;
+  }
+
+  public String getAnotherString() {
+    return anotherString;
+  }
+
+  public void setAnotherString(String anotherString) {
+    this.anotherString = anotherString;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/B.java
+++ b/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/B.java
@@ -1,0 +1,44 @@
+package com.remondis.remap.regression.omitOthersOmitsImplicitMappings;
+
+public class B {
+
+  private String string1;
+  private int string2Length;
+  private String someOtherString;
+
+  public B(String string1, int string2Length, String someOtherString) {
+    super();
+    this.string1 = string1;
+    this.string2Length = string2Length;
+    this.someOtherString = someOtherString;
+  }
+
+  public B() {
+    super();
+  }
+
+  public String getString1() {
+    return string1;
+  }
+
+  public void setString1(String string1) {
+    this.string1 = string1;
+  }
+
+  public int getString2Length() {
+    return string2Length;
+  }
+
+  public void setString2Length(int string2Length) {
+    this.string2Length = string2Length;
+  }
+
+  public String getSomeOtherString() {
+    return someOtherString;
+  }
+
+  public void setSomeOtherString(String someOtherString) {
+    this.someOtherString = someOtherString;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
@@ -1,0 +1,26 @@
+package com.remondis.remap.regression.omitOthersOmitsImplicitMappings;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class MapperTest {
+
+  /**
+   * The bug was, that omitOtherSourceProperties() removed all implicit mappings. In this case the Mapper complained
+   * about field "string1" is not being mapped.
+   */
+  @Test
+  public void shouldNotBreakImplicitMappings() {
+    Mapper<A, B> mapper = Mapping.from(A.class)
+        .to(B.class)
+        .replace(A::getString2, B::getString2Length)
+        .withSkipWhenNull(String::length)
+        .omitOtherSourceProperties()
+        .omitInDestination(B::getSomeOtherString)
+        .mapper();
+    System.out.println(mapper);
+  }
+
+}


### PR DESCRIPTION
- Fixed by adding omits after adding implicit mappings.