### PR TITLE
Nested collections bug

### DIFF
--- a/src/main/java/com/remondis/remap/GenericParameterContext.java
+++ b/src/main/java/com/remondis/remap/GenericParameterContext.java
@@ -1,0 +1,131 @@
+package com.remondis.remap;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Stack;
+
+/**
+ * Holds generic parameter types when traversing recursively through nested generic type declarations.
+ */
+public class GenericParameterContext {
+
+  private Stack<ParameterizedType> stack = new Stack<>();
+  private boolean finished = false;
+  private Class<?> currentType;
+
+  private Method method;
+
+  /**
+   * Creates a new context.
+   *
+   * @param method For this method.
+   */
+  public GenericParameterContext(Method method) {
+    super();
+    this.method = method;
+    init();
+  }
+
+  GenericParameterContext(Stack<ParameterizedType> stack, boolean finished, Class<?> currentType, Method method) {
+    super();
+    this.stack = stack;
+    this.finished = finished;
+    this.currentType = currentType;
+    this.method = method;
+  }
+
+  private void init() {
+    if (method.getGenericReturnType() instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) method.getGenericReturnType();
+      add(parameterizedType);
+      this.currentType = (Class<?>) parameterizedType.getRawType();
+    } else {
+      this.currentType = (Class<?>) method.getGenericReturnType();
+      finish();
+    }
+  }
+
+  private boolean isEmpty() {
+    return stack.isEmpty();
+  }
+
+  /**
+   * Adds a new recursive level generic type traversal.
+   *
+   * @param parameterizedType The current parameterized type.
+   */
+  private void add(ParameterizedType parameterizedType) {
+    if (isFinished()) {
+      throw new IllegalStateException(
+          "The generic parameter context was finished, the concrete type was found. Further use is not supported.");
+    }
+    requireNonNull(parameterizedType, "parameterizedType must not be null.");
+    stack.push(parameterizedType);
+  }
+
+  private boolean isFinished() {
+    return finished;
+  }
+
+  private void finish() {
+    this.finished = true;
+  }
+
+  /**
+   * Returns the current parameterized type.
+   *
+   * @return Returns the current parameterized type.
+   */
+  private ParameterizedType get() {
+    return stack.peek();
+  }
+
+  public Class<?> getCurrentType() {
+    return this.currentType;
+  }
+
+  /**
+   * Traverses the next recursive level in the nested generic types.
+   *
+   * @param genericParameterIndex The generic parameter index. Example: Map&lt;A,B&gt;: A=0, B=1.
+   * @return Return the type after traversing one step.
+   */
+  public GenericParameterContext goInto(int genericParameterIndex) {
+    GenericParameterContext newCtx = new GenericParameterContext(stack, finished, currentType, method);
+    newCtx.findNextGenericTypeFromMethod(genericParameterIndex);
+    return newCtx;
+  }
+
+  /**
+   * Finds the generic return type of a method in nested generics. For example this method returns {@link String} when
+   * called on a method like <code>List&lt;List&lt;Set&lt;String&gt;&gt;&gt; get();</code>.
+   *
+   * @param method The method to analyze.
+   */
+  void findNextGenericTypeFromMethod(int genericParameterIndex) {
+    // If the first type is requested, initialize context.
+    Type type = null;
+
+    ParameterizedType parameterizedType = get();
+    type = parameterizedType.getActualTypeArguments()[genericParameterIndex];
+
+    if (type instanceof ParameterizedType) {
+      parameterizedType = (ParameterizedType) type;
+      add(parameterizedType);
+      this.currentType = (Class<?>) parameterizedType.getRawType();
+    } else {
+      finish();
+      this.currentType = (Class<?>) type;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "GenericParameterContext [currentType=" + currentType + ", currentParameterizedType="
+        + (isEmpty() ? "empty" : get()) + "]";
+  }
+
+}

--- a/src/main/java/com/remondis/remap/GenericParameterContext.java
+++ b/src/main/java/com/remondis/remap/GenericParameterContext.java
@@ -94,7 +94,9 @@ public class GenericParameterContext {
    * @return Return the type after traversing one step.
    */
   public GenericParameterContext goInto(int genericParameterIndex) {
-    GenericParameterContext newCtx = new GenericParameterContext(stack, finished, currentType, method);
+    Stack<ParameterizedType> newStack = new Stack<>();
+    newStack.addAll(stack);
+    GenericParameterContext newCtx = new GenericParameterContext(newStack, finished, currentType, method);
     newCtx.findNextGenericTypeFromMethod(genericParameterIndex);
     return newCtx;
   }

--- a/src/main/java/com/remondis/remap/GenericParameterContext.java
+++ b/src/main/java/com/remondis/remap/GenericParameterContext.java
@@ -79,7 +79,7 @@ public class GenericParameterContext {
    *
    * @return Returns the current parameterized type.
    */
-  private ParameterizedType get() {
+  public ParameterizedType get() {
     return stack.peek();
   }
 

--- a/src/main/java/com/remondis/remap/MappingException.java
+++ b/src/main/java/com/remondis/remap/MappingException.java
@@ -138,18 +138,46 @@ public class MappingException extends RuntimeException {
             .getName()));
   }
 
-  static MappingException denyReassignOnMaps(PropertyDescriptor source, PropertyDescriptor dest) {
-    return new MappingException(String
-        .format("The implicit mapping of maps is not supported. Use a replace operation for properties holding maps."
-            + " Invalid reassign was:\n%s\n->%s", asStringWithType(source), asStringWithType(dest)));
-  }
-
   static MappingException denyMappingOfNull() {
     return new MappingException("Mapper cannot map null object.");
   }
 
   static MappingException unsupportedCollection(Class<?> collectionType) {
     return new MappingException(String.format("The collection type %s is unsupported.", collectionType.getName()));
+  }
+
+  static MappingException incompatibleCollectionMapping(PropertyDescriptor sourceProperty,
+      GenericParameterContext sourceCtx, PropertyDescriptor destinationProperty, GenericParameterContext destCtx) {
+    GenericParameterContext rootSrcCtx = new GenericParameterContext(sourceProperty.getReadMethod());
+    GenericParameterContext rootDestCtx = new GenericParameterContext(destinationProperty.getReadMethod());
+    StringBuilder builder = new StringBuilder("Incompatible nested collections found mapping\n\t");
+    builder.append(asString(sourceProperty))
+        .append(" to ~>\n\t")
+        .append(asString(destinationProperty))
+        .append("\nCannot map ")
+        .append(sourceCtx.getCurrentType()
+            .getSimpleName())
+        .append(" to ")
+        .append(destCtx.getCurrentType()
+            .getSimpleName())
+        .append(".\n")
+        .append("Use replace for manual mapping!\n")
+        .append("\nType nesting is\n\t")
+        .append("-> in source type: ")
+        .append("\n\t")
+        .append(rootSrcCtx.get()
+            .toString())
+        .append("\n\t-> in destination type: ")
+        .append("\n\t")
+        .append(rootDestCtx.get()
+            .toString())
+        .append("\n\tcannot map \n\t")
+        .append(sourceCtx.get()
+            .toString())
+        .append("\n\tto\n\t")
+        .append(destCtx.get()
+            .toString());
+    return new MappingException(builder.toString());
   }
 
 }

--- a/src/main/java/com/remondis/remap/PropertyPathCollectionTransformation.java
+++ b/src/main/java/com/remondis/remap/PropertyPathCollectionTransformation.java
@@ -45,7 +45,7 @@ public class PropertyPathCollectionTransformation<RS, X, RD> extends Transformat
   @SuppressWarnings("unchecked")
   private Get<RS, RD, ?> createGetter(PropertyDescriptor sourceProperty, PropertyPath<RD, RS, ?> propertyPath) {
     Class<RS> genericSourceType = (Class<RS>) ReassignTransformation
-        .findGenericTypeFromMethod(sourceProperty.getReadMethod());
+        .findGenericTypeFromMethod(sourceProperty.getReadMethod(), 0);
     return Getter.newFor(genericSourceType)
         .evaluate(propertyPath);
   }
@@ -54,7 +54,7 @@ public class PropertyPathCollectionTransformation<RS, X, RD> extends Transformat
   private Get<RS, RD, ?> createGetterAndApply(PropertyDescriptor sourceProperty, PropertyPath<X, RS, ?> propertyPath,
       Function<X, RD> transformation) {
     Class<RS> genericSourceType = (Class<RS>) ReassignTransformation
-        .findGenericTypeFromMethod(sourceProperty.getReadMethod());
+        .findGenericTypeFromMethod(sourceProperty.getReadMethod(), 0);
     return Getter.newFor(genericSourceType)
         .evaluate(propertyPath)
         .andApply(transformation);

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -44,28 +44,23 @@ public class ReassignTransformation extends Transformation {
     Object sourceValue = readOrFail(sourceProperty, source);
     // Only if the source value is not null we have to perform the mapping
     if (sourceValue != null) {
-
-      Class<?> sourceType = getSourceType();
-      Class<?> destinationType = getDestinationType();
-
-      Object destinationValue = null;
-      destinationValue = _convert(sourceType, sourceValue, destinationType, destination);
-
+      Object destinationValue = _convert(sourceValue, destination);
       writeOrFail(destinationProperty, destination, destinationValue);
     }
   }
 
-  private Object _convert(Class<?> sourceType, Object sourceValue, Class<?> destinationType, Object destination) {
+  private Object _convert(Object sourceValue, Object destination) {
     Object destinationValue;
-    if (hasMapperFor(sourceType, destinationType)) {
-      InternalMapper mapper = getMapperFor(this.sourceProperty, sourceType, this.destinationProperty, destinationType);
+    if (hasMapperFor(getSourceType(), getDestinationType())) {
+      InternalMapper mapper = getMapperFor(this.sourceProperty, getSourceType(), this.destinationProperty,
+          getDestinationType());
       destinationValue = mapper.map(sourceValue, null);
-    } else if (isCollection(sourceType)) {
+    } else if (isCollection(getSourceType())) {
       Class<?> sourceCollectionType = findGenericTypeFromMethod(this.sourceProperty.getReadMethod());
       Class<?> destinationCollectionType = findGenericTypeFromMethod(this.destinationProperty.getReadMethod());
       destinationValue = convertCollection(sourceCollectionType, sourceValue, destinationCollectionType);
     } else {
-      destinationValue = convertValueMapOver(sourceType, sourceValue, destinationType, destination);
+      destinationValue = convertValueMapOver(getSourceType(), sourceValue, getDestinationType(), destination);
     }
     return destinationValue;
   }

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -171,7 +171,18 @@ public class ReassignTransformation extends Transformation {
   protected void validateTransformation() throws MappingException {
     // we have to check that all required mappers are known for nested mapping
     // if this transformation performs an object mapping, check for known mappers
-    Class<?> sourceType = getSourceType();
+
+    GenericParameterContext sourceCtx = new GenericParameterContext(getSourceProperty().getReadMethod());
+    GenericParameterContext destCtx = new GenericParameterContext(getDestinationProperty().getReadMethod());
+
+    _validateTransformation(sourceCtx, destCtx);
+
+  }
+
+  private void _validateTransformation(GenericParameterContext sourceCtx, GenericParameterContext destCtx) {
+    // TODO: Travers nested types here and check for equal map/collection and existing type mapping.
+    Class<?> sourceType = sourceCtx.getCurrentType();
+    Class<?> destinationType = destCtx.getCurrentType();
     if (isMap(sourceType)) {
       Class<?> sourceMapKeyType = findGenericTypeFromMethod(sourceProperty.getReadMethod(), 0);
       Class<?> destinationMapKeyType = findGenericTypeFromMethod(destinationProperty.getReadMethod(), 0);
@@ -186,7 +197,6 @@ public class ReassignTransformation extends Transformation {
       validateTypeMapping(getSourceProperty(), sourceCollectionType, getDestinationProperty(),
           destinationCollectionType);
     } else {
-      Class<?> destinationType = getDestinationType();
       validateTypeMapping(getSourceProperty(), sourceType, getDestinationProperty(), destinationType);
     }
   }

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -57,41 +57,32 @@ public class ReassignTransformation extends Transformation {
       } else if (isCollection(sourceType)) {
         Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod());
         Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod());
-        destinationValue = convertCollection(sourceProperty, sourceValue, sourceCollectionType, destinationProperty,
-            destinationCollectionType);
+        destinationValue = convertCollection(sourceValue, sourceCollectionType, destinationCollectionType);
       } else {
-        destinationValue = convertValue(sourceProperty, sourceValue, sourceType, destinationProperty, destination,
-            destinationType);
+        destinationValue = convertValue(sourceValue, sourceType, destination, destinationType);
       }
 
       writeOrFail(destinationProperty, destination, destinationValue);
     }
   }
 
-  @SuppressWarnings({
-      "unchecked", "rawtypes"
-  })
-  private Object convertCollection(PropertyDescriptor sourceProperty, Object sourceValue, Class<?> sourceCollectionType,
-      PropertyDescriptor destinationProperty, Class<?> destinationCollectionType) {
-    return _convertCollection(sourceProperty, sourceValue, sourceCollectionType, destinationProperty,
-        destinationCollectionType, 0);
+  private Object convertCollection(Object sourceValue, Class<?> sourceCollectionType,
+      Class<?> destinationCollectionType) {
+    return _convertCollection(sourceValue, sourceCollectionType, destinationCollectionType, 0);
 
   }
 
-  private Object _convertCollection(PropertyDescriptor sourceProperty, Object sourceValue,
-      Class<?> sourceCollectionType, PropertyDescriptor destinationProperty, Class<?> destinationCollectionType,
-      int genericParameterDepth) {
+  private Object _convertCollection(Object sourceValue, Class<?> sourceCollectionType,
+      Class<?> destinationCollectionType, int genericParameterDepth) {
     Collection collection = Collection.class.cast(sourceValue);
     Class<?> collectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod(), genericParameterDepth);
     Collector collector = getCollector(collectionType);
     return collection.stream()
         .map(o -> {
           if (isCollection(o)) {
-            return _convertCollection(sourceProperty, o, sourceCollectionType, destinationProperty,
-                destinationCollectionType, genericParameterDepth + 1);
+            return _convertCollection(o, sourceCollectionType, destinationCollectionType, genericParameterDepth + 1);
           } else {
-            return convertValue(sourceProperty, o, sourceCollectionType, destinationProperty,
-                destinationCollectionType);
+            return convertValue(o, sourceCollectionType, destinationCollectionType);
           }
         })
         .collect(collector);
@@ -100,8 +91,7 @@ public class ReassignTransformation extends Transformation {
   @SuppressWarnings({
       "unchecked", "rawtypes"
   })
-  Object convertValue(PropertyDescriptor sourceProperty, Object sourceValue, Class<?> sourceType,
-      PropertyDescriptor destinationProperty, Class<?> destinationType) {
+  Object convertValue(Object sourceValue, Class<?> sourceType, Class<?> destinationType) {
     if (isReferenceMapping(sourceType, destinationType)) {
       return sourceValue;
     } else {
@@ -114,8 +104,7 @@ public class ReassignTransformation extends Transformation {
   @SuppressWarnings({
       "unchecked", "rawtypes"
   })
-  Object convertValue(PropertyDescriptor sourceProperty, Object sourceValue, Class<?> sourceType,
-      PropertyDescriptor destinationProperty, Object destinationValue, Class<?> destinationType) {
+  Object convertValue(Object sourceValue, Class<?> sourceType, Object destinationValue, Class<?> destinationType) {
     if (isReferenceMapping(sourceType, destinationType)) {
       return sourceValue;
     } else {

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -56,15 +56,14 @@ public class ReassignTransformation extends Transformation {
     Object destinationValue;
     if (hasMapperFor(sourceType, destinationType)) {
       InternalMapper mapper = getMapperFor(this.sourceProperty, sourceType, this.destinationProperty, destinationType);
-      destinationValue = mapper.map(sourceValue, null);
+      return mapper.map(sourceValue, null);
     } else if (isMap(sourceValue)) {
       return convertMap(sourceValue, sourceCtx, destinationCtx);
     } else if (isCollection(sourceValue)) {
-      destinationValue = convertCollection(sourceValue, sourceCtx, destinationCtx);
+      return convertCollection(sourceValue, sourceCtx, destinationCtx);
     } else {
-      destinationValue = convertValueMapOver(sourceType, sourceValue, destinationType, destination);
+      return convertValueMapOver(sourceType, sourceValue, destinationType, destination);
     }
-    return destinationValue;
   }
 
   private Object convertCollection(Object sourceValue, GenericParameterContext sourceCtx,

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -49,20 +49,25 @@ public class ReassignTransformation extends Transformation {
       Class<?> destinationType = getDestinationType();
 
       Object destinationValue = null;
-      if (hasMapperFor(sourceType, destinationType)) {
-        InternalMapper mapper = getMapperFor(getSourceProperty(), sourceType, getDestinationProperty(),
-            destinationType);
-        destinationValue = mapper.map(sourceValue, null);
-      } else if (isCollection(sourceType)) {
-        Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod());
-        Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod());
-        destinationValue = convertCollection(sourceCollectionType, sourceValue, destinationCollectionType);
-      } else {
-        destinationValue = convertValueMapOver(sourceType, sourceValue, destinationType, destination);
-      }
+      destinationValue = _convert(sourceType, sourceValue, destinationType, destination);
 
       writeOrFail(destinationProperty, destination, destinationValue);
     }
+  }
+
+  private Object _convert(Class<?> sourceType, Object sourceValue, Class<?> destinationType, Object destination) {
+    Object destinationValue;
+    if (hasMapperFor(sourceType, destinationType)) {
+      InternalMapper mapper = getMapperFor(this.sourceProperty, sourceType, this.destinationProperty, destinationType);
+      destinationValue = mapper.map(sourceValue, null);
+    } else if (isCollection(sourceType)) {
+      Class<?> sourceCollectionType = findGenericTypeFromMethod(this.sourceProperty.getReadMethod());
+      Class<?> destinationCollectionType = findGenericTypeFromMethod(this.destinationProperty.getReadMethod());
+      destinationValue = convertCollection(sourceCollectionType, sourceValue, destinationCollectionType);
+    } else {
+      destinationValue = convertValueMapOver(sourceType, sourceValue, destinationType, destination);
+    }
+    return destinationValue;
   }
 
   private Object convertCollection(Class<?> sourceCollectionType, Object sourceValue,

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -51,19 +51,25 @@ public class ReassignTransformation extends Transformation {
 
       // Primitive types can be set without any conversion, because we checked type
       // compatibility before.
-      if (hasMapperFor(sourceType, destinationType)) {
-        InternalMapper mapper = getMapperFor(sourceProperty, sourceType, destinationProperty, destinationType);
-        destinationValue = mapper.map(sourceValue, destinationValue);
-      } else if (isCollection(sourceType)) {
-        Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod());
-        Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod());
-        destinationValue = convertCollection(sourceValue, sourceCollectionType, destinationCollectionType);
-      } else {
-        destinationValue = convertValue(sourceValue, sourceType, destination, destinationType);
-      }
+      destinationValue = _convert(destination, sourceValue, destinationValue, sourceType, destinationType);
 
       writeOrFail(destinationProperty, destination, destinationValue);
     }
+  }
+
+  private Object _convert(Object destination, Object sourceValue, Object destinationValue, Class<?> sourceType,
+      Class<?> destinationType) {
+    if (hasMapperFor(sourceType, destinationType)) {
+      InternalMapper mapper = getMapperFor(sourceProperty, sourceType, destinationProperty, destinationType);
+      destinationValue = mapper.map(sourceValue, destinationValue);
+    } else if (isCollection(sourceType)) {
+      Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod());
+      Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod());
+      destinationValue = convertCollection(sourceValue, sourceCollectionType, destinationCollectionType);
+    } else {
+      destinationValue = convertValue(sourceValue, sourceType, destination, destinationType);
+    }
+    return destinationValue;
   }
 
   private Object convertCollection(Object sourceValue, Class<?> sourceCollectionType,

--- a/src/main/java/com/remondis/remap/ReassignTransformation.java
+++ b/src/main/java/com/remondis/remap/ReassignTransformation.java
@@ -51,9 +51,11 @@ public class ReassignTransformation extends Transformation {
     }
   }
 
+  @SuppressWarnings({
+      "unchecked", "rawtypes"
+  })
   private Object _convert(Class<?> sourceType, Object sourceValue, Class<?> destinationType, Object destination,
       GenericParameterContext sourceCtx, GenericParameterContext destinationCtx) {
-    Object destinationValue;
     if (hasMapperFor(sourceType, destinationType)) {
       InternalMapper mapper = getMapperFor(this.sourceProperty, sourceType, this.destinationProperty, destinationType);
       return mapper.map(sourceValue, null);
@@ -66,9 +68,11 @@ public class ReassignTransformation extends Transformation {
     }
   }
 
+  @SuppressWarnings({
+      "unchecked", "rawtypes"
+  })
   private Object convertCollection(Object sourceValue, GenericParameterContext sourceCtx,
       GenericParameterContext destinationCtx) {
-    Class<?> sourceCollectionType = sourceCtx.getCurrentType();
     Class<?> destinationCollectionType = destinationCtx.getCurrentType();
     Collection collection = Collection.class.cast(sourceValue);
     Collector collector = getCollector(destinationCollectionType);
@@ -83,6 +87,9 @@ public class ReassignTransformation extends Transformation {
         .collect(collector);
   }
 
+  @SuppressWarnings({
+      "rawtypes", "unchecked"
+  })
   private Object convertMap(Object sourceValue, GenericParameterContext sourceCtx,
       GenericParameterContext destinationCtx) {
 
@@ -180,22 +187,23 @@ public class ReassignTransformation extends Transformation {
   }
 
   private void _validateTransformation(GenericParameterContext sourceCtx, GenericParameterContext destCtx) {
-    // TODO: Travers nested types here and check for equal map/collection and existing type mapping.
+    // Travers nested types here and check for equal map/collection and existing type mapping.
     Class<?> sourceType = sourceCtx.getCurrentType();
     Class<?> destinationType = destCtx.getCurrentType();
-    if (isMap(sourceType)) {
-      Class<?> sourceMapKeyType = findGenericTypeFromMethod(sourceProperty.getReadMethod(), 0);
-      Class<?> destinationMapKeyType = findGenericTypeFromMethod(destinationProperty.getReadMethod(), 0);
-      Class<?> sourceMapValueType = findGenericTypeFromMethod(sourceProperty.getReadMethod(), 1);
-      Class<?> destinationMapValueType = findGenericTypeFromMethod(destinationProperty.getReadMethod(), 1);
-      validateTypeMapping(getSourceProperty(), sourceMapKeyType, getDestinationProperty(), destinationMapKeyType);
-      validateTypeMapping(getSourceProperty(), sourceMapValueType, getDestinationProperty(), destinationMapValueType);
+    if (isMap(sourceType) && isMap(destinationType)) {
+      GenericParameterContext sourceKeyContext = sourceCtx.goInto(0);
+      GenericParameterContext destKeyContext = destCtx.goInto(0);
+
+      GenericParameterContext sourceValueContext = sourceCtx.goInto(1);
+      GenericParameterContext destValueContext = destCtx.goInto(1);
+
+      _validateTransformation(sourceKeyContext, destKeyContext);
+      _validateTransformation(sourceValueContext, destValueContext);
     }
-    if (isCollection(sourceType)) {
-      Class<?> sourceCollectionType = findGenericTypeFromMethod(sourceProperty.getReadMethod(), 0);
-      Class<?> destinationCollectionType = findGenericTypeFromMethod(destinationProperty.getReadMethod(), 0);
-      validateTypeMapping(getSourceProperty(), sourceCollectionType, getDestinationProperty(),
-          destinationCollectionType);
+    if (isCollection(sourceType) && isCollection(destinationType)) {
+      GenericParameterContext sourceElemType = sourceCtx.goInto(0);
+      GenericParameterContext destElemType = destCtx.goInto(0);
+      _validateTransformation(sourceElemType, destElemType);
     } else {
       validateTypeMapping(getSourceProperty(), sourceType, getDestinationProperty(), destinationType);
     }

--- a/src/test/java/com/remondis/remap/basic/BResource.java
+++ b/src/test/java/com/remondis/remap/basic/BResource.java
@@ -64,12 +64,46 @@ public class BResource {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see java.lang.Object#toString()
    */
   @Override
   public String toString() {
     return "BResource [string=" + string + ", number=" + number + ", integer=" + integer + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((integer == null) ? 0 : integer.hashCode());
+    result = prime * result + number;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BResource other = (BResource) obj;
+    if (integer == null) {
+      if (other.integer != null)
+        return false;
+    } else if (!integer.equals(other.integer))
+      return false;
+    if (number != other.number)
+      return false;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
   }
 
 }

--- a/src/test/java/com/remondis/remap/collections/A.java
+++ b/src/test/java/com/remondis/remap/collections/A.java
@@ -1,88 +1,59 @@
 package com.remondis.remap.collections;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
 import com.remondis.remap.basic.B;
 
 public class A {
 
-  private Set<String> strings;
-  private List<B> bs;
-
-  private List<Set<B>> nestedLists;
+  private List<B> bs = new LinkedList<>();
 
   public A() {
     super();
-  }
-
-  public void addStrings(String... strings) {
-    this.strings = new HashSet<>(Arrays.asList(strings));
   }
 
   public void addBs(B... bs) {
     this.bs = Arrays.asList(bs);
   }
 
-  public void addNestedLists(@SuppressWarnings("unchecked") Set<B>... lists) {
-    this.nestedLists = Arrays.asList(lists);
-  }
-
-  /**
-   * @return the nestedLists
-   */
-  public List<Set<B>> getNestedLists() {
-    return nestedLists;
-  }
-
-  /**
-   * @param nestedLists
-   *        the nestedLists to set
-   */
-  public void setNestedLists(List<Set<B>> nestedLists) {
-    this.nestedLists = nestedLists;
-  }
-
-  /**
-   * @return the strings
-   */
-  public Set<String> getStrings() {
-    return strings;
-  }
-
-  /**
-   * @param strings
-   *        the strings to set
-   */
-  public void setStrings(Set<String> strings) {
-    this.strings = strings;
-  }
-
-  /**
-   * @return the bs
-   */
   public List<B> getBs() {
     return bs;
   }
 
-  /**
-   * @param bs
-   *        the bs to set
-   */
   public void setBs(List<B> bs) {
     this.bs = bs;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see java.lang.Object#toString()
-   */
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((bs == null) ? 0 : bs.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (bs == null) {
+      if (other.bs != null)
+        return false;
+    } else if (!bs.equals(other.bs))
+      return false;
+    return true;
+  }
+
   @Override
   public String toString() {
-    return "A [strings=" + strings + ", bs=" + bs + "]";
+    return "A [bs=" + bs + "]";
   }
 
 }

--- a/src/test/java/com/remondis/remap/collections/AResource.java
+++ b/src/test/java/com/remondis/remap/collections/AResource.java
@@ -12,7 +12,7 @@ public class AResource {
   private Set<String> strings;
   private List<BResource> bs;
 
-  private List<List<BResource>> nestedLists;
+  private Set<List<BResource>> nestedLists;
 
   public AResource() {
     super();
@@ -29,7 +29,7 @@ public class AResource {
   /**
    * @return the nestedLists
    */
-  public List<List<BResource>> getNestedLists() {
+  public Set<List<BResource>> getNestedLists() {
     return nestedLists;
   }
 
@@ -37,7 +37,7 @@ public class AResource {
    * @param nestedLists
    *        the nestedLists to set
    */
-  public void setNestedLists(List<List<BResource>> nestedLists) {
+  public void setNestedLists(Set<List<BResource>> nestedLists) {
     this.nestedLists = nestedLists;
   }
 

--- a/src/test/java/com/remondis/remap/collections/AResource.java
+++ b/src/test/java/com/remondis/remap/collections/AResource.java
@@ -1,84 +1,58 @@
 package com.remondis.remap.collections;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import com.remondis.remap.basic.BResource;
 
 public class AResource {
 
-  private Set<String> strings;
   private List<BResource> bs;
-
-  private Set<List<BResource>> nestedLists;
 
   public AResource() {
     super();
-  }
-
-  public void addStrings(String... strings) {
-    this.strings = new HashSet<>(Arrays.asList(strings));
   }
 
   public void addBs(BResource... bs) {
     this.bs = Arrays.asList(bs);
   }
 
-  /**
-   * @return the nestedLists
-   */
-  public Set<List<BResource>> getNestedLists() {
-    return nestedLists;
-  }
-
-  /**
-   * @param nestedLists
-   *        the nestedLists to set
-   */
-  public void setNestedLists(Set<List<BResource>> nestedLists) {
-    this.nestedLists = nestedLists;
-  }
-
-  /**
-   * @return the strings
-   */
-  public Set<String> getStrings() {
-    return strings;
-  }
-
-  /**
-   * @param strings
-   *        the strings to set
-   */
-  public void setStrings(Set<String> strings) {
-    this.strings = strings;
-  }
-
-  /**
-   * @return the bs
-   */
   public List<BResource> getBs() {
     return bs;
   }
 
-  /**
-   * @param bs
-   *        the bs to set
-   */
   public void setBs(List<BResource> bs) {
     this.bs = bs;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see java.lang.Object#toString()
-   */
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((bs == null) ? 0 : bs.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AResource other = (AResource) obj;
+    if (bs == null) {
+      if (other.bs != null)
+        return false;
+    } else if (!bs.equals(other.bs))
+      return false;
+    return true;
+  }
+
   @Override
   public String toString() {
-    return "A [strings=" + strings + ", bs=" + bs + "]";
+    return "AResource [bs=" + bs + "]";
   }
 
 }

--- a/src/test/java/com/remondis/remap/collections/CollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/CollectionsTest.java
@@ -105,6 +105,13 @@ public class CollectionsTest {
     assertEquals(b2Integer, b2.getInteger());
     assertEquals(b2Integer, br2Actual.getInteger());
 
+    // Assert before mapping (paranoia check)
+    List<Set<B>> nestedListsBefore = a.getNestedLists();
+    assertThat(nestedListsBefore).isInstanceOf(List.class);
+    assertThat(nestedListsBefore.iterator()
+        .next()).isInstanceOf(Set.class);
+
+    // Assert after mapping (collections should be nested with according to the destination types)
     Set<List<BResource>> nestedLists = ar.getNestedLists();
     assertThat(nestedLists).isInstanceOf(Set.class);
     assertThat(nestedLists.iterator()

--- a/src/test/java/com/remondis/remap/collections/CollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/CollectionsTest.java
@@ -1,12 +1,8 @@
 package com.remondis.remap.collections;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -17,24 +13,6 @@ import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
 public class CollectionsTest {
-  @Test
-  public void shouldReassignCollections() {
-    A a = new A();
-    a.addStrings("a", "b", "c");
-    Set<String> expectedSet = a.getStrings();
-
-    Mapper<A, ReassignBean> mapper = Mapping.from(A.class)
-        .to(ReassignBean.class)
-        .reassign(A::getStrings)
-        .to(ReassignBean::getAnotherName)
-        .omitOtherSourceProperties()
-        .mapper();
-
-    ReassignBean b = mapper.map(a);
-
-    assertEquals(expectedSet, b.getAnotherName());
-
-  }
 
   /**
    * There was a bug in collection mappings. It was possible to declare a
@@ -48,7 +26,6 @@ public class CollectionsTest {
         .mapper();
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldMapNestedCollections() {
 
@@ -59,10 +36,6 @@ public class CollectionsTest {
         .to(AResource.class)
         .useMapper(bMapper)
         .mapper();
-
-    String[] stringsArr = new String[] {
-        "A", "B", "C", "D"
-    };
 
     String b1String = "b1String";
     int b1Number = 101;
@@ -75,15 +48,9 @@ public class CollectionsTest {
     B b2 = new B(b2String, b2Number, b2Integer);
 
     A a = new A();
-    a.addStrings(stringsArr);
     a.addBs(b1, b2);
 
-    Set<B> firstList = new HashSet<>(Arrays.asList(b1));
-    Set<B> secondList = new HashSet<>(Arrays.asList(b2));
-    a.addNestedLists(firstList, secondList);
-
     AResource ar = aMapper.map(a);
-    assertEquals(a.getStrings(), ar.getStrings());
     List<B> bs = a.getBs();
     List<BResource> brs = ar.getBs();
     assertEquals(bs.size(), brs.size());
@@ -105,20 +72,8 @@ public class CollectionsTest {
     assertEquals(b2Integer, b2.getInteger());
     assertEquals(b2Integer, br2Actual.getInteger());
 
-    // Assert before mapping (paranoia check)
-    List<Set<B>> nestedListsBefore = a.getNestedLists();
-    assertThat(nestedListsBefore).isInstanceOf(List.class);
-    assertThat(nestedListsBefore.iterator()
-        .next()).isInstanceOf(Set.class);
-
-    // Assert after mapping (collections should be nested with according to the destination types)
-    Set<List<BResource>> nestedLists = ar.getNestedLists();
-    assertThat(nestedLists).isInstanceOf(Set.class);
-    assertThat(nestedLists.iterator()
-        .next()).isInstanceOf(List.class);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldMapCollections() {
 
@@ -128,13 +83,7 @@ public class CollectionsTest {
     Mapper<A, AResource> aMapper = Mapping.from(A.class)
         .to(AResource.class)
         .useMapper(bMapper)
-        .omitInSource(A::getNestedLists)
-        .omitInDestination(AResource::getNestedLists)
         .mapper();
-
-    String[] stringsArr = new String[] {
-        "A", "B", "C", "D"
-    };
 
     String b1String = "b1String";
     int b1Number = 101;
@@ -147,15 +96,9 @@ public class CollectionsTest {
     B b2 = new B(b2String, b2Number, b2Integer);
 
     A a = new A();
-    a.addStrings(stringsArr);
     a.addBs(b1, b2);
 
-    Set<B> firstList = new HashSet<>(Arrays.asList(b1));
-    Set<B> secondList = new HashSet<>(Arrays.asList(b2));
-    a.addNestedLists(firstList, secondList);
-
     AResource ar = aMapper.map(a);
-    assertEquals(a.getStrings(), ar.getStrings());
     List<B> bs = a.getBs();
     List<BResource> brs = ar.getBs();
     assertEquals(bs.size(), brs.size());

--- a/src/test/java/com/remondis/remap/collections/CollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/CollectionsTest.java
@@ -1,5 +1,6 @@
 package com.remondis.remap.collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -104,6 +105,10 @@ public class CollectionsTest {
     assertEquals(b2Integer, b2.getInteger());
     assertEquals(b2Integer, br2Actual.getInteger());
 
+    Set<List<BResource>> nestedLists = ar.getNestedLists();
+    assertThat(nestedLists).isInstanceOf(Set.class);
+    assertThat(nestedLists.iterator()
+        .next()).isInstanceOf(List.class);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/A.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/A.java
@@ -1,0 +1,61 @@
+package com.remondis.remap.collections.fromSetToList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class A {
+
+  private Set<A1> as = new HashSet<>();
+
+  public A(Set<A1> as) {
+    super();
+    this.as = as;
+  }
+
+  public A() {
+    super();
+  }
+
+  public void add(A1 a) {
+    as.add(a);
+  }
+
+  public Set<A1> getAs() {
+    return as;
+  }
+
+  public void setAs(Set<A1> as) {
+    this.as = as;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((as == null) ? 0 : as.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (as == null) {
+      if (other.as != null)
+        return false;
+    } else if (!as.equals(other.as))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "A [as=" + as + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/A1.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/A1.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.collections.fromSetToList;
+
+public class A1 {
+
+  private String string;
+
+  public A1(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A1() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A1 other = (A1) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "A1 [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/A2.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/A2.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.collections.fromSetToList;
+
+public class A2 {
+
+  private String string;
+
+  public A2(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A2() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A2 other = (A2) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "A2 [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/AMapped.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/AMapped.java
@@ -1,0 +1,61 @@
+package com.remondis.remap.collections.fromSetToList;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class AMapped {
+
+  private List<A2> as = new LinkedList<>();
+
+  public AMapped(List<A2> as) {
+    super();
+    this.as = as;
+  }
+
+  public AMapped() {
+    super();
+  }
+
+  public void add(A2 a) {
+    as.add(a);
+  }
+
+  public List<A2> getAs() {
+    return as;
+  }
+
+  public void setAs(List<A2> as) {
+    this.as = as;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((as == null) ? 0 : as.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AMapped other = (AMapped) obj;
+    if (as == null) {
+      if (other.as != null)
+        return false;
+    } else if (!as.equals(other.as))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "AMapped [as=" + as + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.collections.fromSetToList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class FromSetToListTest {
+
+  @Test
+  public void test() {
+    A a = new A();
+    a.add(new A1("a1"));
+    a.add(new A1("a2"));
+    a.add(new A1("a3"));
+
+    Mapper<A, AMapped> mapper = Mapping.from(A.class)
+        .to(AMapped.class)
+        .useMapper(Mapping.from(A1.class)
+            .to(A2.class)
+            .mapper())
+        .mapper();
+
+    AMapped aMapped = mapper.map(a);
+    assertThat(aMapped.getAs()).isInstanceOf(List.class);
+  }
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/A.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/A.java
@@ -1,0 +1,64 @@
+package com.remondis.remap.collections.listAndMaps;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class A {
+
+  private List<Map<String, B>> nestedLists;
+
+  public A() {
+    super();
+  }
+
+  public void addNestedLists(@SuppressWarnings("unchecked") Map<String, B>... lists) {
+    this.nestedLists = Arrays.asList(lists);
+  }
+
+  /**
+   * @return the nestedLists
+   */
+  public List<Map<String, B>> getNestedLists() {
+    return nestedLists;
+  }
+
+  /**
+   * @param nestedLists
+   *        the nestedLists to set
+   */
+  public void setNestedLists(List<Map<String, B>> nestedLists) {
+    this.nestedLists = nestedLists;
+  }
+
+  @Override
+  public String toString() {
+    return "A [nestedLists=" + nestedLists + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((nestedLists == null) ? 0 : nestedLists.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (nestedLists == null) {
+      if (other.nestedLists != null)
+        return false;
+    } else if (!nestedLists.equals(other.nestedLists))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/AResource.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/AResource.java
@@ -1,0 +1,59 @@
+package com.remondis.remap.collections.listAndMaps;
+
+import java.util.Map;
+import java.util.Set;
+
+public class AResource {
+
+  private Set<Map<String, BResource>> nestedLists;
+
+  public AResource() {
+    super();
+  }
+
+  /**
+   * @return the nestedLists
+   */
+  public Set<Map<String, BResource>> getNestedLists() {
+    return nestedLists;
+  }
+
+  /**
+   * @param nestedLists
+   *        the nestedLists to set
+   */
+  public void setNestedLists(Set<Map<String, BResource>> nestedLists) {
+    this.nestedLists = nestedLists;
+  }
+
+  @Override
+  public String toString() {
+    return "AResource [nestedLists=" + nestedLists + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((nestedLists == null) ? 0 : nestedLists.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AResource other = (AResource) obj;
+    if (nestedLists == null) {
+      if (other.nestedLists != null)
+        return false;
+    } else if (!nestedLists.equals(other.nestedLists))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/B.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/B.java
@@ -1,0 +1,75 @@
+package com.remondis.remap.collections.listAndMaps;
+
+public class B {
+
+  private String string;
+  private int number;
+  private Integer integer;
+
+  public B() {
+    super();
+  }
+
+  public B(String string, int number, Integer integer) {
+    super();
+    this.string = string;
+    this.number = number;
+    this.integer = integer;
+  }
+
+  /**
+   * @return the string
+   */
+  public String getString() {
+    return string;
+  }
+
+  /**
+   * @param string
+   *        the string to set
+   */
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  /**
+   * @return the number
+   */
+  public int getNumber() {
+    return number;
+  }
+
+  /**
+   * @param number
+   *        the number to set
+   */
+  public void setNumber(int number) {
+    this.number = number;
+  }
+
+  /**
+   * @return the integer
+   */
+  public Integer getInteger() {
+    return integer;
+  }
+
+  /**
+   * @param integer
+   *        the integer to set
+   */
+  public void setInteger(Integer integer) {
+    this.integer = integer;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "B         [string=" + string + ", number=" + number + ", integer=" + integer + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/BResource.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/BResource.java
@@ -1,0 +1,75 @@
+package com.remondis.remap.collections.listAndMaps;
+
+public class BResource {
+
+  private String string;
+  private int number;
+  private Integer integer;
+
+  public BResource() {
+    super();
+  }
+
+  public BResource(String string, int number, Integer integer) {
+    super();
+    this.string = string;
+    this.number = number;
+    this.integer = integer;
+  }
+
+  /**
+   * @return the string
+   */
+  public String getString() {
+    return string;
+  }
+
+  /**
+   * @param string
+   *        the string to set
+   */
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  /**
+   * @return the number
+   */
+  public int getNumber() {
+    return number;
+  }
+
+  /**
+   * @param number
+   *        the number to set
+   */
+  public void setNumber(int number) {
+    this.number = number;
+  }
+
+  /**
+   * @return the integer
+   */
+  public Integer getInteger() {
+    return integer;
+  }
+
+  /**
+   * @param integer
+   *        the integer to set
+   */
+  public void setInteger(Integer integer) {
+    this.integer = integer;
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "BResource [string=" + string + ", number=" + number + ", integer=" + integer + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
@@ -1,0 +1,68 @@
+package com.remondis.remap.collections.listAndMaps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class ListAndMapsTest {
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldMapNestedCollections() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+        .to(BResource.class)
+        .mapper();
+    Mapper<A, AResource> aMapper = Mapping.from(A.class)
+        .to(AResource.class)
+        .useMapper(bMapper)
+        .mapper();
+
+    String b1String = "b1String";
+    int b1Number = 101;
+    Integer b1Integer = 201;
+    B b1 = new B(b1String, b1Number, b1Integer);
+
+    String b2String = "b2String";
+    int b2Number = 331;
+    Integer b2Integer = 441;
+    B b2 = new B(b2String, b2Number, b2Integer);
+
+    A a = new A();
+
+    Map<String, B> firstList = new HashMap<>();
+    firstList.put("a", b1);
+    Map<String, B> secondList = new HashMap<>();
+    secondList.put("b", b2);
+    a.addNestedLists(firstList, secondList);
+
+    AResource ar = aMapper.map(a);
+
+    // Assert before mapping (paranoia check)
+    List<Map<String, B>> nestedListsBefore = a.getNestedLists();
+    assertThat(nestedListsBefore).isInstanceOf(List.class);
+    assertThat(nestedListsBefore.iterator()
+        .next()).isInstanceOf(Map.class);
+
+    // Assert after mapping (collections should be nested with according to the destination types)
+    Set<Map<String, BResource>> nestedLists = ar.getNestedLists();
+    assertThat(nestedLists).isInstanceOf(Set.class);
+    assertThat(nestedLists.iterator()
+        .next()).isInstanceOf(Map.class);
+
+    // TODO: After implementing map support, uncomment this.
+    // assertThat(nestedLists.iterator()
+    // .next()
+    // .entrySet()
+    // .iterator()
+    // .next()
+    // .getValue()).isInstanceOf(BResource.class);
+  }
+}

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
@@ -57,12 +57,11 @@ public class ListAndMapsTest {
     assertThat(nestedLists.iterator()
         .next()).isInstanceOf(Map.class);
 
-    // TODO: After implementing map support, uncomment this.
-    // assertThat(nestedLists.iterator()
-    // .next()
-    // .entrySet()
-    // .iterator()
-    // .next()
-    // .getValue()).isInstanceOf(BResource.class);
+    assertThat(nestedLists.iterator()
+        .next()
+        .entrySet()
+        .iterator()
+        .next()
+        .getValue()).isInstanceOf(BResource.class);
   }
 }

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/A.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/A.java
@@ -1,0 +1,66 @@
+package com.remondis.remap.collections.nestedCollections;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import com.remondis.remap.basic.B;
+
+public class A {
+
+  private List<Set<B>> nestedLists;
+
+  public A() {
+    super();
+  }
+
+  public void addNestedLists(@SuppressWarnings("unchecked") Set<B>... lists) {
+    this.nestedLists = Arrays.asList(lists);
+  }
+
+  /**
+   * @return the nestedLists
+   */
+  public List<Set<B>> getNestedLists() {
+    return nestedLists;
+  }
+
+  /**
+   * @param nestedLists
+   *        the nestedLists to set
+   */
+  public void setNestedLists(List<Set<B>> nestedLists) {
+    this.nestedLists = nestedLists;
+  }
+
+  @Override
+  public String toString() {
+    return "A [nestedLists=" + nestedLists + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((nestedLists == null) ? 0 : nestedLists.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (nestedLists == null) {
+      if (other.nestedLists != null)
+        return false;
+    } else if (!nestedLists.equals(other.nestedLists))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/AResource.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/AResource.java
@@ -1,0 +1,61 @@
+package com.remondis.remap.collections.nestedCollections;
+
+import java.util.List;
+import java.util.Set;
+
+import com.remondis.remap.basic.BResource;
+
+public class AResource {
+
+  private Set<List<BResource>> nestedLists;
+
+  public AResource() {
+    super();
+  }
+
+  /**
+   * @return the nestedLists
+   */
+  public Set<List<BResource>> getNestedLists() {
+    return nestedLists;
+  }
+
+  /**
+   * @param nestedLists
+   *        the nestedLists to set
+   */
+  public void setNestedLists(Set<List<BResource>> nestedLists) {
+    this.nestedLists = nestedLists;
+  }
+
+  @Override
+  public String toString() {
+    return "AResource [nestedLists=" + nestedLists + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((nestedLists == null) ? 0 : nestedLists.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AResource other = (AResource) obj;
+    if (nestedLists == null) {
+      if (other.nestedLists != null)
+        return false;
+    } else if (!nestedLists.equals(other.nestedLists))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
@@ -1,6 +1,7 @@
 package com.remondis.remap.collections.nestedCollections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,10 +12,22 @@ import org.junit.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
 import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
 public class NestedCollectionsTest {
+
+  @Test
+  public void shouldDoMapperValidation() {
+    assertThatThrownBy(() -> Mapping.from(A.class)
+        .to(AResource.class)
+        .mapper()).isInstanceOf(MappingException.class)
+            .hasMessageContaining(
+                "No mapper found for type mapping from com.remondis.remap.basic.B to com.remondis.remap.basic.BResource.");
+
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void shouldMapNestedCollections() {

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
@@ -15,6 +15,7 @@ import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
 public class NestedCollectionsTest {
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldMapNestedCollections() {
 
@@ -25,10 +26,6 @@ public class NestedCollectionsTest {
         .to(AResource.class)
         .useMapper(bMapper)
         .mapper();
-
-    String[] stringsArr = new String[] {
-        "A", "B", "C", "D"
-    };
 
     String b1String = "b1String";
     int b1Number = 101;

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
@@ -1,0 +1,64 @@
+package com.remondis.remap.collections.nestedCollections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.basic.B;
+import com.remondis.remap.basic.BResource;
+
+public class NestedCollectionsTest {
+  @Test
+  public void shouldMapNestedCollections() {
+
+    Mapper<B, BResource> bMapper = Mapping.from(B.class)
+        .to(BResource.class)
+        .mapper();
+    Mapper<A, AResource> aMapper = Mapping.from(A.class)
+        .to(AResource.class)
+        .useMapper(bMapper)
+        .mapper();
+
+    String[] stringsArr = new String[] {
+        "A", "B", "C", "D"
+    };
+
+    String b1String = "b1String";
+    int b1Number = 101;
+    Integer b1Integer = 201;
+    B b1 = new B(b1String, b1Number, b1Integer);
+
+    String b2String = "b2String";
+    int b2Number = 331;
+    Integer b2Integer = 441;
+    B b2 = new B(b2String, b2Number, b2Integer);
+
+    A a = new A();
+
+    Set<B> firstList = new HashSet<>(Arrays.asList(b1));
+    Set<B> secondList = new HashSet<>(Arrays.asList(b2));
+    a.addNestedLists(firstList, secondList);
+
+    AResource ar = aMapper.map(a);
+
+    // Assert before mapping (paranoia check)
+    List<Set<B>> nestedListsBefore = a.getNestedLists();
+    assertThat(nestedListsBefore).isInstanceOf(List.class);
+    assertThat(nestedListsBefore.iterator()
+        .next()).isInstanceOf(Set.class);
+
+    // Assert after mapping (collections should be nested with according to the destination types)
+    Set<List<BResource>> nestedLists = ar.getNestedLists();
+    assertThat(nestedLists).isInstanceOf(Set.class);
+    assertThat(nestedLists.iterator()
+        .next()).isInstanceOf(List.class);
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/A.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/A.java
@@ -1,0 +1,57 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+import java.util.List;
+import java.util.Set;
+
+public class A {
+
+  private List<Set<Set<B>>> list;
+
+  public A(List<Set<Set<B>>> list) {
+    super();
+    this.list = list;
+  }
+
+  public A() {
+    super();
+  }
+
+  public List<Set<Set<B>>> getList() {
+    return list;
+  }
+
+  public void setList(List<Set<Set<B>>> list) {
+    this.list = list;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((list == null) ? 0 : list.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (list == null) {
+      if (other.list != null)
+        return false;
+    } else if (!list.equals(other.list))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "A [list=" + list + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/AMapped.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/AMapped.java
@@ -1,0 +1,58 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AMapped {
+
+  private List<Set<Map<BMapped, CMapped>>> list;
+
+  public AMapped(List<Set<Map<BMapped, CMapped>>> list) {
+    super();
+    this.list = list;
+  }
+
+  public AMapped() {
+    super();
+  }
+
+  public List<Set<Map<BMapped, CMapped>>> getList() {
+    return list;
+  }
+
+  public void setList(List<Set<Map<BMapped, CMapped>>> list) {
+    this.list = list;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((list == null) ? 0 : list.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AMapped other = (AMapped) obj;
+    if (list == null) {
+      if (other.list != null)
+        return false;
+    } else if (!list.equals(other.list))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "AMapped [list=" + list + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/B.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/B.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+public class B {
+
+  private String string;
+
+  public B(String string) {
+    super();
+    this.string = string;
+  }
+
+  public B() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    B other = (B) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "B [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/BMapped.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/BMapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+public class BMapped {
+
+  private String string;
+
+  public BMapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public BMapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BMapped other = (BMapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "BMapped [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/C.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/C.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+public class C {
+
+  private String string;
+
+  public C(String string) {
+    super();
+    this.string = string;
+  }
+
+  public C() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    C other = (C) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "C [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/CMapped.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/CMapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+public class CMapped {
+
+  private String string;
+
+  public CMapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public CMapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CMapped other = (CMapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "CMapped [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
@@ -1,0 +1,23 @@
+package com.remondis.remap.maps.incompatibleListMapTypeValidation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
+
+public class TypeValidationTest {
+
+  @Test
+  public void shouldDetectIncompatibleCollections() {
+    assertThatThrownBy(() -> {
+      Mapping.from(A.class)
+          .to(AMapped.class)
+          .mapper();
+    }).isInstanceOf(MappingException.class)
+        .hasMessageContaining("java.util.Set<com.remondis.remap.maps.incompatibleListMapTypeValidation.B>\n\tto"
+            + "\n\tjava.util.Map<com.remondis.remap.maps.incompatibleListMapTypeValidation.BMapped, com.remondis.remap.maps.incompatibleListMapTypeValidation.CMapped>");
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/A.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/A.java
@@ -6,18 +6,22 @@ import java.util.Set;
 
 public class A {
 
-  private List<Set<Map<String, B>>> list;
+  private List<Set<Map<B, C>>> list;
 
-  public A(List<Set<Map<String, B>>> list) {
+  public A(List<Set<Map<B, C>>> list) {
     super();
     this.list = list;
   }
 
-  public List<Set<Map<String, B>>> getList() {
+  public A() {
+    super();
+  }
+
+  public List<Set<Map<B, C>>> getList() {
     return list;
   }
 
-  public void setList(List<Set<Map<String, B>>> list) {
+  public void setList(List<Set<Map<B, C>>> list) {
     this.list = list;
   }
 

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/A.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/A.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class A {
+
+  private List<Set<Map<String, B>>> list;
+
+  public A(List<Set<Map<String, B>>> list) {
+    super();
+    this.list = list;
+  }
+
+  public List<Set<Map<String, B>>> getList() {
+    return list;
+  }
+
+  public void setList(List<Set<Map<String, B>>> list) {
+    this.list = list;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((list == null) ? 0 : list.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (list == null) {
+      if (other.list != null)
+        return false;
+    } else if (!list.equals(other.list))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "A [list=" + list + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/AMapped.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/AMapped.java
@@ -6,9 +6,9 @@ import java.util.Set;
 
 public class AMapped {
 
-  private List<Set<Map<String, BMapped>>> list;
+  private List<Set<Map<BMapped, CMapped>>> list;
 
-  public AMapped(List<Set<Map<String, BMapped>>> list) {
+  public AMapped(List<Set<Map<BMapped, CMapped>>> list) {
     super();
     this.list = list;
   }
@@ -17,11 +17,11 @@ public class AMapped {
     super();
   }
 
-  public List<Set<Map<String, BMapped>>> getList() {
+  public List<Set<Map<BMapped, CMapped>>> getList() {
     return list;
   }
 
-  public void setList(List<Set<Map<String, BMapped>>> list) {
+  public void setList(List<Set<Map<BMapped, CMapped>>> list) {
     this.list = list;
   }
 

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/AMapped.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/AMapped.java
@@ -1,0 +1,58 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AMapped {
+
+  private List<Set<Map<String, BMapped>>> list;
+
+  public AMapped(List<Set<Map<String, BMapped>>> list) {
+    super();
+    this.list = list;
+  }
+
+  public AMapped() {
+    super();
+  }
+
+  public List<Set<Map<String, BMapped>>> getList() {
+    return list;
+  }
+
+  public void setList(List<Set<Map<String, BMapped>>> list) {
+    this.list = list;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((list == null) ? 0 : list.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AMapped other = (AMapped) obj;
+    if (list == null) {
+      if (other.list != null)
+        return false;
+    } else if (!list.equals(other.list))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "AMapped [list=" + list + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/B.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/B.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+public class B {
+
+  private String string;
+
+  public B(String string) {
+    super();
+    this.string = string;
+  }
+
+  public B() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    B other = (B) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "B [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/BMapped.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/BMapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+public class BMapped {
+
+  private String string;
+
+  public BMapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public BMapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BMapped other = (BMapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "BMapped [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/C.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/C.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+public class C {
+
+  private String string;
+
+  public C(String string) {
+    super();
+    this.string = string;
+  }
+
+  public C() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    C other = (C) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "C [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/CMapped.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/CMapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+public class CMapped {
+
+  private String string;
+
+  public CMapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public CMapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CMapped other = (CMapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "CMapped [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
@@ -1,0 +1,23 @@
+package com.remondis.remap.maps.listMapTypeValidation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
+
+public class TypeValidationTest {
+
+  @Test
+  public void shouldDetectBothNestedGenericTypes() {
+
+    assertThatThrownBy(() -> {
+      Mapping.from(A.class)
+          .to(AMapped.class)
+          .mapper();
+    }).isInstanceOf(MappingException.class)
+        .hasMessageContaining(
+            "No mapper found for type mapping from com.remondis.remap.maps.listMapTypeValidation.B to com.remondis.remap.maps.listMapTypeValidation.BMapped.");
+  }
+}

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
+import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
@@ -11,13 +12,31 @@ public class TypeValidationTest {
 
   @Test
   public void shouldDetectBothNestedGenericTypes() {
+    Mapper<B, BMapped> bMapper = Mapping.from(B.class)
+        .to(BMapped.class)
+        .mapper();
+
+    Mapper<C, CMapped> cMapper = Mapping.from(C.class)
+        .to(CMapped.class)
+        .mapper();
 
     assertThatThrownBy(() -> {
       Mapping.from(A.class)
           .to(AMapped.class)
+          .useMapper(cMapper)
           .mapper();
     }).isInstanceOf(MappingException.class)
         .hasMessageContaining(
             "No mapper found for type mapping from com.remondis.remap.maps.listMapTypeValidation.B to com.remondis.remap.maps.listMapTypeValidation.BMapped.");
+
+    assertThatThrownBy(() -> {
+      Mapping.from(A.class)
+          .to(AMapped.class)
+          .useMapper(bMapper)
+          .mapper();
+    }).isInstanceOf(MappingException.class)
+        .hasMessageContaining(
+            "No mapper found for type mapping from com.remondis.remap.maps.listMapTypeValidation.C to com.remondis.remap.maps.listMapTypeValidation.CMapped.");
+
   }
 }

--- a/src/test/java/com/remondis/remap/maps/nested/A.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A.java
@@ -1,0 +1,58 @@
+package com.remondis.remap.maps.nested;
+
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+public class A {
+
+  private Map<List<A1>, Map<A2, A3>> map;
+
+  public A() {
+    super();
+    this.map = new Hashtable<>();
+  }
+
+  public void add(List<A1> key, Map<A2, A3> value) {
+    this.map.put(key, value);
+  }
+
+  public Map<List<A1>, Map<A2, A3>> getMap() {
+    return map;
+  }
+
+  public void setMap(Map<List<A1>, Map<A2, A3>> map) {
+    this.map = map;
+  }
+
+  @Override
+  public String toString() {
+    return "A [bmap=" + map + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((map == null) ? 0 : map.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A other = (A) obj;
+    if (map == null) {
+      if (other.map != null)
+        return false;
+    } else if (!map.equals(other.map))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A1.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A1.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A1 {
+
+  private String string;
+
+  public A1(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A1() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A1 [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A1 other = (A1) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A1Mapped.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A1Mapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A1Mapped {
+
+  private String string;
+
+  public A1Mapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A1Mapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A1Mapped [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A1Mapped other = (A1Mapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A2.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A2.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A2 {
+
+  private String string;
+
+  public A2(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A2() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A2 [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A2 other = (A2) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A2Mapped.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A2Mapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A2Mapped {
+
+  private String string;
+
+  public A2Mapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A2Mapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A2Mapped [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A2Mapped other = (A2Mapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A3.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A3.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A3 {
+
+  private String string;
+
+  public A3(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A3() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A3 [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A3 other = (A3) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/A3Mapped.java
+++ b/src/test/java/com/remondis/remap/maps/nested/A3Mapped.java
@@ -1,0 +1,54 @@
+package com.remondis.remap.maps.nested;
+
+public class A3Mapped {
+
+  private String string;
+
+  public A3Mapped(String string) {
+    super();
+    this.string = string;
+  }
+
+  public A3Mapped() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public String toString() {
+    return "A3Mapped [string=" + string + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    A3Mapped other = (A3Mapped) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/AMapped.java
+++ b/src/test/java/com/remondis/remap/maps/nested/AMapped.java
@@ -1,0 +1,58 @@
+package com.remondis.remap.maps.nested;
+
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+public class AMapped {
+
+  private Map<List<A1Mapped>, Map<A2Mapped, A3Mapped>> map;
+
+  public AMapped() {
+    super();
+    this.map = new Hashtable<>();
+  }
+
+  public void add(List<A1Mapped> key, Map<A2Mapped, A3Mapped> value) {
+    this.map.put(key, value);
+  }
+
+  public Map<List<A1Mapped>, Map<A2Mapped, A3Mapped>> getMap() {
+    return map;
+  }
+
+  public void setMap(Map<List<A1Mapped>, Map<A2Mapped, A3Mapped>> map) {
+    this.map = map;
+  }
+
+  @Override
+  public String toString() {
+    return "AMapped [map=" + map + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((map == null) ? 0 : map.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AMapped other = (AMapped) obj;
+    if (map == null) {
+      if (other.map != null)
+        return false;
+    } else if (!map.equals(other.map))
+      return false;
+    return true;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
@@ -2,6 +2,7 @@ package com.remondis.remap.maps.nested;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Hashtable;
 import java.util.List;
@@ -11,8 +12,48 @@ import org.junit.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
 
 public class MapsTest {
+
+  @Test
+  public void shouldDoMapperValidation() {
+    Mapper<A1, A1Mapped> a1Mapper = Mapping.from(A1.class)
+        .to(A1Mapped.class)
+        .mapper();
+
+    Mapper<A2, A2Mapped> a2Mapper = Mapping.from(A2.class)
+        .to(A2Mapped.class)
+        .mapper();
+
+    Mapper<A3, A3Mapped> a3Mapper = Mapping.from(A3.class)
+        .to(A3Mapped.class)
+        .mapper();
+
+    assertThatThrownBy(() -> Mapping.from(A.class)
+        .to(AMapped.class)
+        .useMapper(a2Mapper)
+        .useMapper(a3Mapper)
+        .mapper()).isInstanceOf(MappingException.class)
+            .hasMessageContaining(
+                "No mapper found for type mapping from com.remondis.remap.maps.nested.A1 to com.remondis.remap.maps.nested.A1Mapped.");
+
+    assertThatThrownBy(() -> Mapping.from(A.class)
+        .to(AMapped.class)
+        .useMapper(a1Mapper)
+        .useMapper(a3Mapper)
+        .mapper()).isInstanceOf(MappingException.class)
+            .hasMessageContaining(
+                "No mapper found for type mapping from com.remondis.remap.maps.nested.A2 to com.remondis.remap.maps.nested.A2Mapped.");
+
+    assertThatThrownBy(() -> Mapping.from(A.class)
+        .to(AMapped.class)
+        .useMapper(a1Mapper)
+        .useMapper(a2Mapper)
+        .mapper()).isInstanceOf(MappingException.class)
+            .hasMessageContaining(
+                "No mapper found for type mapping from com.remondis.remap.maps.nested.A3 to com.remondis.remap.maps.nested.A3Mapped.");
+  }
 
   @Test
   public void shouldMapNestedKeyValues() {

--- a/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
@@ -1,8 +1,10 @@
 package com.remondis.remap.maps.nested;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -47,7 +49,43 @@ public class MapsTest {
 
     AMapped mapped = mapper.map(a);
 
-    System.out.println(mapped);
+    assertThat(mapped.getMap()).isInstanceOf(Map.class);
+    assertThat(mapped.getMap()
+        .entrySet()
+        .iterator()
+        .next()
+        .getKey()).isInstanceOf(List.class);
+    assertThat(mapped.getMap()
+        .entrySet()
+        .iterator()
+        .next()
+        .getKey()
+        .iterator()
+        .next()).isInstanceOf(A1Mapped.class);
+    assertThat(mapped.getMap()
+        .entrySet()
+        .iterator()
+        .next()
+        .getValue()).isInstanceOf(Map.class);
+    assertThat(mapped.getMap()
+        .entrySet()
+        .iterator()
+        .next()
+        .getValue()
+        .entrySet()
+        .iterator()
+        .next()
+        .getKey()).isInstanceOf(A2Mapped.class);
+    assertThat(mapped.getMap()
+        .entrySet()
+        .iterator()
+        .next()
+        .getValue()
+        .entrySet()
+        .iterator()
+        .next()
+        .getValue()).isInstanceOf(A3Mapped.class);
+
   }
 
   private Map<A2, A3> asMap(A2 key, A3 value) {

--- a/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
@@ -1,0 +1,59 @@
+package com.remondis.remap.maps.nested;
+
+import static java.util.Arrays.asList;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class MapsTest {
+
+  @Test
+  public void shouldMapNestedKeyValues() {
+    A1 a1 = new A1("key1");
+    A2 key1 = new A2("value-key1");
+    A3 value1 = new A3("value-value1");
+
+    A1 a2 = new A1("key2");
+    A2 key2 = new A2("value-key2");
+    A3 value2 = new A3("value-value2");
+
+    Mapper<A1, A1Mapped> a1Mapper = Mapping.from(A1.class)
+        .to(A1Mapped.class)
+        .mapper();
+
+    Mapper<A2, A2Mapped> a2Mapper = Mapping.from(A2.class)
+        .to(A2Mapped.class)
+        .mapper();
+
+    Mapper<A3, A3Mapped> a3Mapper = Mapping.from(A3.class)
+        .to(A3Mapped.class)
+        .mapper();
+
+    Mapper<A, AMapped> mapper = Mapping.from(A.class)
+        .to(AMapped.class)
+        .useMapper(a1Mapper)
+        .useMapper(a2Mapper)
+        .useMapper(a3Mapper)
+        .mapper();
+
+    A a = new A();
+    a.add(asList(a1), asMap(key1, value1));
+    a.add(asList(a2), asMap(key2, value2));
+
+    AMapped mapped = mapper.map(a);
+
+    System.out.println(mapped);
+  }
+
+  private Map<A2, A3> asMap(A2 key, A3 value) {
+    Map<A2, A3> map = new Hashtable<A2, A3>();
+    map.put(key, value);
+    return map;
+  }
+
+}


### PR DESCRIPTION
ReMap did not map collections according to the nested destination types. Instead the source type nesting was used. This resulted in wrong types in the nested collections after mapping.

The tests did not recognized this, because the types were not asserted.

Fixed, by analyzing the destination type nesting.