### PR TITLE
Generic types should map without any errors

### DIFF
--- a/src/main/java/com/remondis/remap/GenericParameterContext.java
+++ b/src/main/java/com/remondis/remap/GenericParameterContext.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Stack;
 
 /**
@@ -38,12 +39,16 @@ public class GenericParameterContext {
   }
 
   private void init() {
-    if (method.getGenericReturnType() instanceof ParameterizedType) {
-      ParameterizedType parameterizedType = (ParameterizedType) method.getGenericReturnType();
+    Type genericReturnType = method.getGenericReturnType();
+    if (genericReturnType instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) genericReturnType;
       add(parameterizedType);
       this.currentType = (Class<?>) parameterizedType.getRawType();
+    } else if (genericReturnType instanceof TypeVariable) {
+      this.currentType = Object.class;
+      finish();
     } else {
-      this.currentType = (Class<?>) method.getGenericReturnType();
+      this.currentType = (Class<?>) genericReturnType;
       finish();
     }
   }

--- a/src/test/java/com/remondis/remap/generics/Bean.java
+++ b/src/test/java/com/remondis/remap/generics/Bean.java
@@ -1,0 +1,23 @@
+package com.remondis.remap.generics;
+
+public class Bean<T> {
+
+  private T object;
+
+  public Bean(T object) {
+    super();
+    this.object = object;
+  }
+
+  public Bean() {
+  }
+
+  public T getObject() {
+    return object;
+  }
+
+  public void setObject(T object) {
+    this.object = object;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/generics/Bean2.java
+++ b/src/test/java/com/remondis/remap/generics/Bean2.java
@@ -1,0 +1,23 @@
+package com.remondis.remap.generics;
+
+public class Bean2<T> {
+
+  private T reference;
+
+  public Bean2() {
+  }
+
+  public Bean2(T reference) {
+    super();
+    this.reference = reference;
+  }
+
+  public T getReference() {
+    return reference;
+  }
+
+  public void setReference(T reference) {
+    this.reference = reference;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/generics/GenericsTest.java
+++ b/src/test/java/com/remondis/remap/generics/GenericsTest.java
@@ -1,6 +1,7 @@
 package com.remondis.remap.generics;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
@@ -8,6 +9,22 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
 public class GenericsTest {
+
+  @Test
+  public void shouldMapGenericType() {
+    Mapper<Bean, Bean2> mapper = Mapping.from(Bean.class)
+        .to(Bean2.class)
+        .reassign(Bean::getObject)
+        .to(Bean2::getReference)
+        .mapper();
+
+    String string = "String";
+    Bean<String> source = new Bean<>(string);
+    Bean2 bean2 = mapper.map(source);
+
+    assertSame(string, bean2.getReference());
+
+  }
 
   @Test
   public void shouldMap() {


### PR DESCRIPTION
When implementing the nested collection mappings, the type check was
implemented without support for generics at runtime.
To fix this, the generic type for type variables that are erased at
runtime is Object.

A future release should support generics on an API level like suggested in #54 .