### PR TITLE
Trying to reproduce the bug mentioned in #144

### DIFF
--- a/src/test/java/com/remondis/remap/regression/reassignMapBug/MapOwner.java
+++ b/src/test/java/com/remondis/remap/regression/reassignMapBug/MapOwner.java
@@ -1,0 +1,30 @@
+package com.remondis.remap.regression.reassignMapBug;
+
+import java.util.LinkedHashMap;
+
+public class MapOwner {
+  private LinkedHashMap<String, String> map;
+
+  public MapOwner() {
+    super();
+  }
+
+  public MapOwner(LinkedHashMap<String, String> map) {
+    super();
+    this.map = map;
+  }
+
+  public LinkedHashMap<String, String> getMap() {
+    return map;
+  }
+
+  public void setMap(LinkedHashMap<String, String> map) {
+    this.map = map;
+  }
+
+  @Override
+  public String toString() {
+    return "MapOwner [map=" + map + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/regression/reassignMapBug/MapOwnerTarget.java
+++ b/src/test/java/com/remondis/remap/regression/reassignMapBug/MapOwnerTarget.java
@@ -1,0 +1,30 @@
+package com.remondis.remap.regression.reassignMapBug;
+
+import java.util.LinkedHashMap;
+
+public class MapOwnerTarget {
+  private LinkedHashMap<String, String> anotherMap;
+
+  public MapOwnerTarget() {
+    super();
+  }
+
+  public MapOwnerTarget(LinkedHashMap<String, String> anotherMap) {
+    super();
+    this.anotherMap = anotherMap;
+  }
+
+  public LinkedHashMap<String, String> getAnotherMap() {
+    return anotherMap;
+  }
+
+  public void setAnotherMap(LinkedHashMap<String, String> anotherMap) {
+    this.anotherMap = anotherMap;
+  }
+
+  @Override
+  public String toString() {
+    return "MapOwnerTargetOld [anotherMap=" + anotherMap + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/remap/regression/reassignMapBug/ReassignMapTest.java
+++ b/src/test/java/com/remondis/remap/regression/reassignMapBug/ReassignMapTest.java
@@ -1,0 +1,33 @@
+package com.remondis.remap.regression.reassignMapBug;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.LinkedHashMap;
+
+import org.junit.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+public class ReassignMapTest {
+
+  @Test
+  public void shouldReassignMapsWithoutException() {
+
+    Mapper<MapOwner, MapOwnerTarget> mapper = Mapping.from(MapOwner.class)
+        .to(MapOwnerTarget.class)
+        .reassign(MapOwner::getMap)
+        .to(MapOwnerTarget::getAnotherMap)
+        .mapper();
+
+    LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+    map.put("key", "value");
+    map.put("key1", "value1");
+
+    MapOwner mapOwner = new MapOwner(map);
+    MapOwnerTarget mapTarget = mapper.map(mapOwner);
+
+    assertNotNull(mapTarget);
+
+  }
+}


### PR DESCRIPTION
Trying to reproduce the bug mentioned in #144 

Findings:
Currently the mapper analyzes the type of properties. If the source
value of a property is an instance of a Map, the map conversion is
triggered.
The map conversion creates a map instance using Collectors.toMap
function. The map instance might not be assignment compatible with the
target value of the bean.

This is some kind of hidden convention: The problem does not occur as
long as the bean properties use super types like Map, List, Set etc.