### PR TITLE
Feat support restructure in mapping model

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ ReMap maps a objects of a source to a destination type. As per default ReMap tri
 
 ## Great news
 
+### Now mapping of fluent-style setters is supported
+
+Thanks to @djarnis73 ReMap now supports fluent-style setters. This relaxes the Java Bean convention in a way, that bean setter methods are now allowed to have a return type different from `void`
+
+How to use:
+
+```
+Mapper<FluentSetterDto, FluentSetterDto> m = Mapping.from(FluentSetterDto.class)
+        .to(FluentSetterDto.class)
+        .allowFluentSetters()
+        .mapper();
+FluentSetterDto expected = new FluentSetterDto().setInteger(5)
+        .setI(22)
+        .setS("str")
+        .setB1(true)
+        .setB2(true);
+FluentSetterDto actual = m.map(expected);
+```
+_This example is taken from [here](src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java)_
+
+**Note:** To add this feature in a backwards compatible way, you have to activate it using `.allowFluentSetters()`.
+
+
+
 ### Now mapping of Maps is supported
 
 Since version `4.1.16` ReMap supports the mapping of maps as well as mapping of generic nesting of collections/maps as long as the collection types (collection or map) match on source and destination fields.
@@ -157,6 +181,7 @@ ReMap supports
 * unit testing of mapping specifications
 * mapping without invasively changing code of involved objects
 * overwrite fields in an instance by specifying the target instance for the mapping
+* mapping of fluent-style setters (setters having a return type)
 
 ## Limitations
 
@@ -732,6 +757,11 @@ This bug was fixed in `net.minidev:accessors-smart:1.2` but is still present in 
 This workaround was tested and should work for most cases. Please file an issue if you are experiencing problems.
 
 # Migration guide
+
+## Sidenote for 4.3.0
+ReMap was extended to support fluent-style setter methods. Older versions of ReMap only support Java Bean compliant setter methods with return type `void`. Now fluent style setter methods are supported in a way, that a setter method might have a return type.
+
+No migrations necessary - this feature is backwards compatible.
 
 ## Sidenote for 4.2.7
 ReMap migrated to byte-buddy thanks to @Karlender. Since cglib is unmaintained ReMap would not be compatible to JDK17+. The migration is just an internal refactoring in ReMap - this sidenote is just about the dependency of ReMap to byte-buddy.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.2.8</version>
+    <version>4.3.0</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.2.6</version>
+    <version>4.2.7</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.2.7</version>
+    <version>4.3.0</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/src/main/java/com/remondis/remap/AssertConfiguration.java
+++ b/src/main/java/com/remondis/remap/AssertConfiguration.java
@@ -89,7 +89,8 @@ public class AssertConfiguration<S, D> {
   public <RS> ReassignAssertBuilder<S, D, RS> expectReassign(FieldSelector<S> sourceSelector) {
     denyNull("sourceSelector", sourceSelector);
     PropertyDescriptor sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, ASSIGN, getMapping().getSource(),
-        sourceSelector);
+        sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     ReassignAssertBuilder<S, D, RS> reassignBuilder = new ReassignAssertBuilder<S, D, RS>(sourceProperty,
         getMapping().getDestination(), this);
     return reassignBuilder;
@@ -110,9 +111,11 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RS> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE, TRANSFORM,
-        getMapping().getSource(), sourceSelector);
+        getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
 
     ReplaceAssertBuilder<S, D, RD, RS> builder = new ReplaceAssertBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -129,7 +132,8 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     SetAssertBuilder<S, D, RD> builder = new SetAssertBuilder<>(destProperty, this);
     return builder;
   }
@@ -145,7 +149,8 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     RestructureAssertBuilder<S, D, RD> builder = new RestructureAssertBuilder<>(destProperty, this);
     return builder;
   }
@@ -164,9 +169,11 @@ public class AssertConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<Collection<RS>> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, getMapping().getSource(), sourceSelector);
+        ReplaceBuilder.TRANSFORM, getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     TypedPropertyDescriptor<Collection<RD>> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, getMapping().getDestination(), destinationSelector);
+        ReplaceBuilder.TRANSFORM, getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
 
     ReplaceCollectionAssertBuilder<S, D, RD, RS> builder = new ReplaceCollectionAssertBuilder<>(sourceProperty,
         destProperty, this);
@@ -191,7 +198,8 @@ public class AssertConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     // Omit in destination
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.SOURCE, OMIT_FIELD_SOURCE,
-        getMapping().getSource(), sourceSelector);
+        getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     OmitTransformation omitSource = omitSource(getMapping(), propertyDescriptor);
     _add(omitSource);
     return this;
@@ -235,7 +243,8 @@ public class AssertConfiguration<S, D> {
   public AssertConfiguration<S, D> expectOmitInDestination(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.DESTINATION, OMIT_FIELD_DEST,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     OmitTransformation omitDestination = omitDestination(getMapping(), propertyDescriptor);
     _add(omitDestination);
     return this;

--- a/src/main/java/com/remondis/remap/AssertConfiguration.java
+++ b/src/main/java/com/remondis/remap/AssertConfiguration.java
@@ -72,6 +72,8 @@ public class AssertConfiguration<S, D> {
 
   private boolean expectWriteNullIfSourceIsNull = false;
 
+  private boolean expectFluentSettersAllowed = false;
+
   AssertConfiguration(Mapper<S, D> mapper) {
     denyNull("mapper", mapper);
     this.mapper = mapper;
@@ -220,6 +222,16 @@ public class AssertConfiguration<S, D> {
   }
 
   /**
+   * Expects the mapper to allow fluent setter methods.
+   *
+   * @return Returns this instance for further configuration.
+   */
+  public AssertConfiguration<S, D> expectFluentSettersAllowed() {
+    this.expectFluentSettersAllowed = true;
+    return this;
+  }
+
+  /**
    * Expects the mapper to suppress creation of implicit mappings. Note: This requires the user to define the mappings
    * explicitly using {@link MappingConfiguration#reassign(FieldSelector)} or any other mapping operation. Therefore all
    * this
@@ -292,6 +304,7 @@ public class AssertConfiguration<S, D> {
   public void ensure() throws AssertionError {
     checkImplicitMappingStrategy();
     checkNullHandling();
+    checkFluentSetters();
     checkReplaceTransformations();
 
     checkVerifications();
@@ -323,6 +336,18 @@ public class AssertConfiguration<S, D> {
         .isWriteNull() && !expectWriteNullIfSourceIsNull) {
       throw new AssertionError("The mapper was expected to skip mapping if the source value is null, "
           + "but the current mapper is configured to write null if source value is null.");
+    }
+  }
+
+  private void checkFluentSetters() {
+    if (!mapper.getMapping()
+        .isFluentSettersAllowed() && expectFluentSettersAllowed) {
+      throw new AssertionError("The mapper was expected to support fluent setter methods, "
+          + "but the current mapper is configured to only handle Java Bean compliant setter methods.");
+    } else if (mapper.getMapping()
+        .isFluentSettersAllowed() && !expectFluentSettersAllowed) {
+      throw new AssertionError("The mapper was expected to only support Java Bean compliant setter methods, "
+          + "but the current mapper is configured to also support fluent setter methods.");
     }
   }
 

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -654,9 +654,9 @@ public class MappingConfiguration<S, D> {
   }
 
   /**
-   * Relaxes the strict java bean requirement that setters should return void, thus allowing for and mapped classes to
+   * Relaxes the strict java bean requirement that setters should return void, thus allowing for mapped classes to
    * be <em>fluent</em>.
-   * 
+   *
    * @return Returns this object for method chaining.
    */
   public MappingConfiguration<S, D> allowFluentSetters() {

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -99,6 +99,11 @@ public class MappingConfiguration<S, D> {
    */
   private boolean writeNullIfSourceIsNull;
 
+  /**
+   * Relax strict java beans requirement about setters must have Void return type.
+   */
+  private boolean allowFluentSetters;
+
   MappingConfiguration(Class<S> source, Class<D> destination) {
     this.source = source;
     this.destination = destination;
@@ -120,7 +125,7 @@ public class MappingConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.DESTINATION, OMIT_FIELD_DEST,
-        destination, destinationSelector);
+        destination, destinationSelector, allowFluentSetters);
     OmitTransformation omitDestination = OmitTransformation.omitDestination(this, propertyDescriptor);
     omitMapping(mappedDestinationProperties, propertyDescriptor, omitDestination);
     return this;
@@ -215,7 +220,7 @@ public class MappingConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     // Omit in source
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.SOURCE, OMIT_FIELD_SOURCE, this.source,
-        sourceSelector);
+        sourceSelector, allowFluentSetters);
     OmitTransformation omitSource = OmitTransformation.omitSource(this, propertyDescriptor);
     omitMapping(mappedSourceProperties, propertyDescriptor, omitSource);
     return this;
@@ -231,7 +236,7 @@ public class MappingConfiguration<S, D> {
   public <RS> ReassignBuilder<S, D> reassign(FieldSelector<S> sourceSelector) {
     denyNull("sourceSelector", sourceSelector);
     PropertyDescriptor typedSourceProperty = getPropertyFromFieldSelector(Target.SOURCE, ReassignBuilder.ASSIGN,
-        this.source, sourceSelector);
+        this.source, sourceSelector, allowFluentSetters);
     ReassignBuilder<S, D> reassignBuilder = new ReassignBuilder<>(typedSourceProperty, destination, this);
     return reassignBuilder;
   }
@@ -254,9 +259,9 @@ public class MappingConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RS> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, this.source, sourceSelector);
+        ReplaceBuilder.TRANSFORM, this.source, sourceSelector, allowFluentSetters);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
 
     ReplaceBuilder<S, D, RD, RS> builder = new ReplaceBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -275,7 +280,7 @@ public class MappingConfiguration<S, D> {
   public <RD> SetBuilder<S, D, RD> set(TypedSelector<RD, D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
     SetBuilder<S, D, RD> builder = new SetBuilder<>(destProperty, this);
     return builder;
   }
@@ -292,7 +297,7 @@ public class MappingConfiguration<S, D> {
   public <RD> RestructureBuilder<S, D, RD> restructure(TypedSelector<RD, D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
     return new RestructureBuilder<S, D, RD>(this, destProperty);
   }
 
@@ -313,9 +318,9 @@ public class MappingConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<Collection<RS>> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, this.source, sourceSelector);
+        ReplaceBuilder.TRANSFORM, this.source, sourceSelector, allowFluentSetters);
     TypedPropertyDescriptor<Collection<RD>> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
 
     ReplaceCollectionBuilder<S, D, RD, RS> builder = new ReplaceCollectionBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -485,7 +490,7 @@ public class MappingConfiguration<S, D> {
    */
   private <T> Set<PropertyDescriptor> getUnmappedProperties(Class<T> type,
       Set<PropertyDescriptor> mappedSourceProperties, Target targetType) {
-    Set<PropertyDescriptor> allSourceProperties = Properties.getProperties(type, targetType);
+    Set<PropertyDescriptor> allSourceProperties = Properties.getProperties(type, targetType, allowFluentSetters);
     allSourceProperties.removeAll(mappedSourceProperties);
     return allSourceProperties;
   }
@@ -503,7 +508,7 @@ public class MappingConfiguration<S, D> {
    * @throws MappingException if a property was specified for mapping but not invoked.
    */
   static <R, T> TypedPropertyDescriptor<R> getTypedPropertyFromFieldSelector(Target target, String configurationMethod,
-      Class<T> sensorType, TypedSelector<R, T> selector) {
+      Class<T> sensorType, TypedSelector<R, T> selector, boolean fluentSetters) {
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     T sensor = invocationSensor.getSensor();
     // perform the selector lambda on the sensor
@@ -516,7 +521,7 @@ public class MappingConfiguration<S, D> {
       // get the property name
       String propertyName = trackedPropertyNames.get(0);
       // find the property descriptor or fail with an exception
-      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName);
+      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
       TypedPropertyDescriptor<R> tpd = new TypedPropertyDescriptor<R>();
       tpd.returnValue = returnValue;
       tpd.property = property;
@@ -539,7 +544,7 @@ public class MappingConfiguration<S, D> {
    * @throws MappingException if a property was specified for mapping but not invoked.
    */
   static <T> PropertyDescriptor getPropertyFromFieldSelector(Target target, String configurationMethod,
-      Class<T> sensorType, FieldSelector<T> selector) {
+      Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     T sensor = invocationSensor.getSensor();
     // perform the selector lambda on the sensor
@@ -552,7 +557,7 @@ public class MappingConfiguration<S, D> {
       // get the property name
       String propertyName = trackedPropertyNames.get(0);
       // find the property descriptor or fail with an exception
-      return getPropertyDescriptorOrFail(target, sensorType, propertyName);
+      return getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
     } else {
       throw zeroInteractions(configurationMethod);
     }
@@ -566,9 +571,10 @@ public class MappingConfiguration<S, D> {
    * @param type The inspected type.
    * @param propertyName The property name
    */
-  static PropertyDescriptor getPropertyDescriptorOrFail(Target target, Class<?> type, String propertyName) {
+  static PropertyDescriptor getPropertyDescriptorOrFail(Target target, Class<?> type, String propertyName,
+      boolean fluentSetters) {
     Optional<PropertyDescriptor> property;
-    property = Properties.getProperties(type, target)
+    property = Properties.getProperties(type, target, fluentSetters)
         .stream()
         .filter(pd -> pd.getName()
             .equals(propertyName))
@@ -645,6 +651,21 @@ public class MappingConfiguration<S, D> {
   public MappingConfiguration<S, D> writeNullIfSourceIsNull() {
     this.writeNullIfSourceIsNull = true;
     return this;
+  }
+
+  /**
+   * Relaxes the strict java bean requirement that setters should return void, thus allowing for and mapped classes to
+   * be <em>fluent</em>.
+   * 
+   * @return Returns this object for method chaining.
+   */
+  public MappingConfiguration<S, D> allowFluentSetters() {
+    this.allowFluentSetters = true;
+    return this;
+  }
+
+  public boolean isFluentSettersAllowed() {
+    return allowFluentSetters;
   }
 
   /**

--- a/src/main/java/com/remondis/remap/MappingModel.java
+++ b/src/main/java/com/remondis/remap/MappingModel.java
@@ -77,12 +77,13 @@ public class MappingModel<S, D> {
     PropertyDescriptor destinationProperty = null;
 
     if (nonNull(sourceSelector)) {
-      sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, "findMapping", mapping.getSource(), sourceSelector);
+      sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, "findMapping", mapping.getSource(), sourceSelector,
+          mapping.isFluentSettersAllowed());
     }
 
     if (nonNull(destinationSelector)) {
       destinationProperty = getPropertyFromFieldSelector(Target.DESTINATION, "findMapping", mapping.getDestination(),
-          destinationSelector);
+          destinationSelector, mapping.isFluentSettersAllowed());
     }
 
     Predicate<String> sourcePredicate = isNull(sourceProperty) ? null : nameEqualsPredicate(sourceProperty.getName());

--- a/src/main/java/com/remondis/remap/Properties.java
+++ b/src/main/java/com/remondis/remap/Properties.java
@@ -7,6 +7,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -106,13 +107,21 @@ class Properties {
    *
    * @param inspectType The type to inspect.
    * @param targetType The type of mapping target.
+   * @param fluentSetters if true, setters that return a value are allowed in the mapping.
    * @return Returns the list of {@link PropertyDescriptor}s that grant read and write access.
    * @throws MappingException Thrown on any introspection error.
    */
-  static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType) {
+  static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType, boolean fluentSetters) {
     try {
       BeanInfo beanInfo = Introspector.getBeanInfo(inspectType);
       PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
+      if (propertyDescriptors != null && fluentSetters && targetType == Target.DESTINATION) {
+        for (PropertyDescriptor pd : propertyDescriptors) {
+          if (pd.getWriteMethod() == null) {
+            checkForAndSetFluentWriteMethod(inspectType, pd);
+          }
+        }
+      }
       return new HashSet<>(Arrays.asList(propertyDescriptors)
           .stream()
           .filter(pd -> !pd.getName()
@@ -128,6 +137,26 @@ class Properties {
           .collect(Collectors.toList()));
     } catch (IntrospectionException e) {
       throw new MappingException(String.format("Cannot introspect the type %s.", inspectType.getName()));
+    }
+  }
+
+  /**
+   * Tries to see if a fluent setXXX method exists even though it was not found by the initial retrospection.
+   * If a setter exists set it as the property descriptors write method.
+   */
+  private static void checkForAndSetFluentWriteMethod(Class<?> inspectType, PropertyDescriptor pd) {
+    String writeMethodName = pd.getName();
+    writeMethodName = "set" + writeMethodName.substring(0, 1)
+        .toUpperCase() + writeMethodName.substring(1);
+    try {
+      Method setMethod = inspectType.getDeclaredMethod(writeMethodName, pd.getPropertyType());
+      if (Modifier.isPublic(setMethod.getModifiers())) {
+        pd.setWriteMethod(setMethod);
+      }
+    } catch (NoSuchMethodException e) {
+      // just ignore, the method does not have to exist
+    } catch (IntrospectionException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
@@ -43,7 +43,8 @@ public class ReassignAssertBuilder<S, D, RS> {
   public AssertConfiguration<S, D> to(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor destinationProperty = getPropertyFromFieldSelector(Target.DESTINATION, ReassignBuilder.ASSIGN,
-        this.destination, destinationSelector);
+        this.destination, destinationSelector, asserts.getMapping()
+            .isFluentSettersAllowed());
     ReassignTransformation transformation = new ReassignTransformation(asserts.getMapping(), sourceProperty,
         destinationProperty);
     asserts.addAssertion(transformation);

--- a/src/main/java/com/remondis/remap/ReassignBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignBuilder.java
@@ -39,7 +39,7 @@ public class ReassignBuilder<S, D> {
   public MappingConfiguration<S, D> to(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor destProperty = getPropertyFromFieldSelector(Target.DESTINATION, ASSIGN, destination,
-        destinationSelector);
+        destinationSelector, mapping.isFluentSettersAllowed());
     ReassignTransformation transformation = new ReassignTransformation(mapping, sourceProperty, destProperty);
     mapping.addMapping(sourceProperty, destProperty, transformation);
     return mapping;

--- a/src/main/java/com/remondis/remap/RestructureTransformation.java
+++ b/src/main/java/com/remondis/remap/RestructureTransformation.java
@@ -84,7 +84,7 @@ class RestructureTransformation<S, D, RD> extends Transformation {
   /**
    * @return Returns the {@link Mapper} used to restructure the destination field.
    */
-  Mapper<S, RD> getRestructureMapper() {
+  protected Mapper<S, RD> getRestructureMapper() {
     return restructureMapper;
   }
 

--- a/src/main/java/com/remondis/remap/Transformation.java
+++ b/src/main/java/com/remondis/remap/Transformation.java
@@ -87,11 +87,7 @@ abstract class Transformation {
   }
 
   /**
-   * Performs a single transformation step while mapping. In contrast to
-   * {@link #performValueTransformation(PropertyDescriptor, Object, PropertyDescriptor, Object)} this method should
-   * implement field access to read/write mapping values. This method should delegate to
-   * {@link #performValueTransformation(PropertyDescriptor, Object, PropertyDescriptor, Object)} to perform the actual
-   * value mapping.
+   * Performs a single transformation step while mapping.
    *
    * @param sourceProperty The source property
    * @param source The source object to map from.

--- a/src/test/java/com/remondis/remap/MapperTest.java
+++ b/src/test/java/com/remondis/remap/MapperTest.java
@@ -18,37 +18,37 @@ import org.junit.Test;
  */
 public class MapperTest {
 
-  private Mapper<A, A> mapper;
+  private Mapper<StringDto, StringDto> mapper;
 
   @Before
   public void setup() {
-    this.mapper = Mapping.from(A.class)
-        .to(A.class)
+    this.mapper = Mapping.from(StringDto.class)
+        .to(StringDto.class)
         .mapper();
   }
 
   @Test
   public void shouldMapEmptyList() {
-    List<A> list = mapper.map(Collections.emptyList());
+    List<StringDto> list = mapper.map(Collections.emptyList());
     assertTrue(list.isEmpty());
   }
 
   @Test
   public void shouldMapEmptySet() {
-    Set<A> list = mapper.map(Collections.emptySet());
+    Set<StringDto> list = mapper.map(Collections.emptySet());
     assertTrue(list.isEmpty());
   }
 
   @Test
   public void shouldMapNull() {
-    A returnValue = mapper.mapOptional(null);
+    StringDto returnValue = mapper.mapOptional(null);
     assertNull(returnValue);
   }
 
   @Test
   public void shouldMapOptional() {
     String expectedString = "string";
-    A returnValue = mapper.mapOptional(new A(expectedString));
+    StringDto returnValue = mapper.mapOptional(new StringDto(expectedString));
     assertNotNull(returnValue);
     assertEquals(expectedString, returnValue.getString());
   }
@@ -56,8 +56,8 @@ public class MapperTest {
   @Test
   public void shouldMapDefault() {
     String expectedString = "string";
-    A expectedA = new A(expectedString);
-    A returnValue = mapper.mapOrDefault(null, expectedA);
+    StringDto expectedA = new StringDto(expectedString);
+    StringDto returnValue = mapper.mapOrDefault(null, expectedA);
     assertNotNull(returnValue);
     assertSame(expectedA, returnValue);
   }
@@ -65,9 +65,9 @@ public class MapperTest {
   @Test
   public void shouldNotMapDefault() {
     String expectedString = "string";
-    A expectedA = new A(expectedString);
-    A notExpectedDefault = new A("someOtherString");
-    A returnValue = mapper.mapOrDefault(expectedA, notExpectedDefault);
+    StringDto expectedA = new StringDto(expectedString);
+    StringDto notExpectedDefault = new StringDto("someOtherString");
+    StringDto returnValue = mapper.mapOrDefault(expectedA, notExpectedDefault);
     assertNotNull(returnValue);
     assertEquals(expectedA, returnValue);
   }

--- a/src/test/java/com/remondis/remap/PropertiesTest.java
+++ b/src/test/java/com/remondis/remap/PropertiesTest.java
@@ -1,0 +1,56 @@
+package com.remondis.remap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyDescriptor;
+import java.util.Optional;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import com.remondis.remap.fluent.FluentSetterDto;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PropertiesTest {
+
+  @Test
+  public void a() {
+    // Changes the property descriptor persistently (vm-wide?).
+    // Some cache is working here
+    Optional<PropertyDescriptor> pdFluentSetter = Properties
+        .getProperties(FluentSetterDto.class, Target.DESTINATION, true)
+        .stream()
+        .filter(pd -> pd.getName()
+            .equals("B1"))
+        .findFirst();
+    assertTrue(pdFluentSetter.isPresent());
+
+  }
+
+  @Test
+  public void b() {
+    Optional<PropertyDescriptor> pdFluentSetterNotThere = Properties
+        .getProperties(FluentSetterDto.class, Target.DESTINATION, false)
+        .stream()
+        .filter(pd -> pd.getName()
+            .equals("B1"))
+        .findFirst();
+
+    assertFalse(pdFluentSetterNotThere.isPresent());
+  }
+
+  @Test
+  public void c() {
+    Optional<PropertyDescriptor> pdFluentSetter = Properties
+        .getProperties(FluentSetterDto.class, Target.DESTINATION, false)
+        .stream()
+        .filter(pd -> pd.getName()
+            .equals("B1"))
+        .findFirst();
+
+    assertFalse(pdFluentSetter.isPresent());
+  }
+
+}

--- a/src/test/java/com/remondis/remap/PropertiesTest.java
+++ b/src/test/java/com/remondis/remap/PropertiesTest.java
@@ -17,28 +17,28 @@ public class PropertiesTest {
 
   @Test
   public void a() {
+    Optional<PropertyDescriptor> pdFluentSetterNotThere = Properties
+        .getProperties(FluentSetterDto.class, Target.DESTINATION, false)
+        .stream()
+        .filter(pd -> pd.getName()
+            .equals("b1"))
+        .findFirst();
+
+    assertFalse(pdFluentSetterNotThere.isPresent());
+  }
+
+  @Test
+  public void b() {
     // Changes the property descriptor persistently (vm-wide?).
     // Some cache is working here
     Optional<PropertyDescriptor> pdFluentSetter = Properties
         .getProperties(FluentSetterDto.class, Target.DESTINATION, true)
         .stream()
         .filter(pd -> pd.getName()
-            .equals("B1"))
+            .equals("b1"))
         .findFirst();
     assertTrue(pdFluentSetter.isPresent());
 
-  }
-
-  @Test
-  public void b() {
-    Optional<PropertyDescriptor> pdFluentSetterNotThere = Properties
-        .getProperties(FluentSetterDto.class, Target.DESTINATION, false)
-        .stream()
-        .filter(pd -> pd.getName()
-            .equals("B1"))
-        .findFirst();
-
-    assertFalse(pdFluentSetterNotThere.isPresent());
   }
 
   @Test
@@ -47,7 +47,7 @@ public class PropertiesTest {
         .getProperties(FluentSetterDto.class, Target.DESTINATION, false)
         .stream()
         .filter(pd -> pd.getName()
-            .equals("B1"))
+            .equals("b1"))
         .findFirst();
 
     assertFalse(pdFluentSetter.isPresent());

--- a/src/test/java/com/remondis/remap/PropertiesTest.java
+++ b/src/test/java/com/remondis/remap/PropertiesTest.java
@@ -23,7 +23,6 @@ public class PropertiesTest {
         .filter(pd -> pd.getName()
             .equals("b1"))
         .findFirst();
-
     assertFalse(pdFluentSetterNotThere.isPresent());
   }
 

--- a/src/test/java/com/remondis/remap/StringDto.java
+++ b/src/test/java/com/remondis/remap/StringDto.java
@@ -1,15 +1,15 @@
 package com.remondis.remap;
 
-public class A {
+public class StringDto {
 
   private String string;
 
-  public A(String string) {
+  public StringDto(String string) {
     super();
     this.string = string;
   }
 
-  public A() {
+  public StringDto() {
     super();
   }
 
@@ -37,7 +37,7 @@ public class A {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    A other = (A) obj;
+    StringDto other = (StringDto) obj;
     if (string == null) {
       if (other.string != null)
         return false;

--- a/src/test/java/com/remondis/remap/fluent/A.java
+++ b/src/test/java/com/remondis/remap/fluent/A.java
@@ -1,0 +1,56 @@
+package com.remondis.remap.fluent;
+
+public class A {
+
+  private Integer integer;
+  private int i;
+  private String s;
+  private boolean b1;
+  private boolean b2;
+
+  public Integer getInteger() {
+    return integer;
+  }
+
+  public A setInteger(Integer integer) {
+    this.integer = integer;
+    return this;
+  }
+
+  public int getI() {
+    return integer;
+  }
+
+  public A setI(int i) {
+    this.i = i;
+    return this;
+  }
+
+  public String getS() {
+    return s;
+  }
+
+  public A setS(String s) {
+    this.s = s;
+    return this;
+  }
+
+  public boolean getB1() {
+    return b1;
+  }
+
+  public A setB1(boolean b) {
+    this.b1 = b;
+    return this;
+  }
+
+  public boolean isB2() {
+    return b2;
+  }
+
+  public A setB2(boolean b) {
+    this.b2 = b;
+    return this;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
+++ b/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
@@ -1,34 +1,51 @@
 package com.remondis.remap.fluent;
 
-import com.remondis.remap.Mapper;
-import com.remondis.remap.Mapping;
-import com.remondis.remap.MappingException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingConfiguration;
+import com.remondis.remap.MappingException;
 
 public class ChainedSetterTest {
 
   @Test
   public void testChainedSetter() {
-    Mapper<A, A> m = Mapping.from(A.class)
-        .to(A.class)
+    Mapper<FluentSetterDto, FluentSetterDto> m = Mapping.from(FluentSetterDto.class)
+        .to(FluentSetterDto.class)
         .allowFluentSetters()
         .mapper();
-    A expected = new A().setInteger(5)
+    FluentSetterDto expected = new FluentSetterDto().setInteger(5)
         .setI(22)
         .setS("str")
         .setB1(true)
         .setB2(true);
-    A actual = m.map(expected);
+    FluentSetterDto actual = m.map(expected);
     assertThat(actual).isEqualToComparingFieldByField(expected);
   }
 
   @Test(expected = MappingException.class)
   public void checkConfigurationOfChainedSetters() {
-    Mapping.from(A.class)
-        .to(A.class)
+    Mapping.from(FluentSetterDto.class)
+        .to(FluentSetterDto.class)
         .mapper();
   }
 
+  @Test
+  public void shouldNotComplainAboutMissingMappings_ifFluentSettersEnabled() {
+    Mapping.from(FluentSetterDto.class)
+        .to(FluentSetterDto.class)
+        .allowFluentSetters()
+        .mapper();
+  }
+
+  @Test
+  public void fluentSettersShouldBeDisabledByDefault_backwardsCompatibility() {
+    MappingConfiguration<FluentSetterDto, FluentSetterDto> mappingConfiguration = Mapping.from(FluentSetterDto.class)
+        .to(FluentSetterDto.class);
+    assertFalse(mappingConfiguration.isFluentSettersAllowed());
+  }
 }

--- a/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
+++ b/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
@@ -1,0 +1,34 @@
+package com.remondis.remap.fluent;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChainedSetterTest {
+
+  @Test
+  public void testChainedSetter() {
+    Mapper<A, A> m = Mapping.from(A.class)
+        .to(A.class)
+        .allowFluentSetters()
+        .mapper();
+    A expected = new A().setInteger(5)
+        .setI(22)
+        .setS("str")
+        .setB1(true)
+        .setB2(true);
+    A actual = m.map(expected);
+    assertThat(actual).isEqualToComparingFieldByField(expected);
+  }
+
+  @Test(expected = MappingException.class)
+  public void checkConfigurationOfChainedSetters() {
+    Mapping.from(A.class)
+        .to(A.class)
+        .mapper();
+  }
+
+}

--- a/src/test/java/com/remondis/remap/fluent/FluentSetterDto.java
+++ b/src/test/java/com/remondis/remap/fluent/FluentSetterDto.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.fluent;
 
-public class A {
+public class FluentSetterDto {
 
   private Integer integer;
   private int i;
@@ -12,7 +12,7 @@ public class A {
     return integer;
   }
 
-  public A setInteger(Integer integer) {
+  public FluentSetterDto setInteger(Integer integer) {
     this.integer = integer;
     return this;
   }
@@ -21,7 +21,7 @@ public class A {
     return integer;
   }
 
-  public A setI(int i) {
+  public FluentSetterDto setI(int i) {
     this.i = i;
     return this;
   }
@@ -30,7 +30,7 @@ public class A {
     return s;
   }
 
-  public A setS(String s) {
+  public FluentSetterDto setS(String s) {
     this.s = s;
     return this;
   }
@@ -39,7 +39,7 @@ public class A {
     return b1;
   }
 
-  public A setB1(boolean b) {
+  public FluentSetterDto setB1(boolean b) {
     this.b1 = b;
     return this;
   }
@@ -48,7 +48,7 @@ public class A {
     return b2;
   }
 
-  public A setB2(boolean b) {
+  public FluentSetterDto setB2(boolean b) {
     this.b2 = b;
     return this;
   }

--- a/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
+++ b/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
@@ -1,17 +1,28 @@
 package com.remondis.remap.restructure.ndepth;
 
-import com.remondis.remap.AssertMapping;
-import com.remondis.remap.Mapper;
-import com.remondis.remap.Mapping;
-import com.remondis.remap.restructure.Address;
-import com.remondis.remap.restructure.Bean;
-import com.remondis.resample.Samples;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertSame;
 
+import org.junit.Test;
+
+import com.remondis.remap.AssertMapping;
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingModel;
+import com.remondis.remap.restructure.Address;
+import com.remondis.remap.restructure.Bean;
+import com.remondis.resample.Samples;
+
 public class NdepthRestructureTest {
+
+  @Test
+  public void shouldReturnMappingModel_n_depth_for_Restructure_n_depth() {
+
+    Mapper<Bean, Bean2> mapper = createMapper();
+    MappingModel<Bean, Bean2>.TransformationSearchResult result = mapper.getMappingModel()
+        .findMappingBySource(MappingModel.nameEqualsPredicateIgnoreCase("city"));
+    System.out.println(result);
+  }
 
   @Test
   public void shouldRestructure_n_depth() {


### PR DESCRIPTION
Feature: Support restructure operation in mapping model

Before feature: The mapping model for mappings involving restructure
operations only contained omit operations for fields that take part in
the restructure operations.

After feature: The mapping model now contains all transformations for
fields that take part in any nested restructure operation defined by a
mapper in the transitive mapping graph. This was done to make any
conversion of a source to destination field accesible even if defined by
resturcture operation.
