### PR TITLE
Fix dynamically loaded classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.2.7</version>
+    <version>4.2.8</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/src/main/java/com/remondis/remap/InvocationSensor.java
+++ b/src/main/java/com/remondis/remap/InvocationSensor.java
@@ -38,13 +38,19 @@ public class InvocationSensor<T> {
    * @param superType the class type for which the proxy should be created
    */
   public InvocationSensor(Class<T> superType) {
+    ClassLoader classLoader;
+    if (isNull(superType) || isNull(superType.getClassLoader())) {
+      classLoader = getSystemClassLoader();
+    } else {
+      classLoader = superType.getClassLoader();
+    }
     T po = null;
     try {
       po = (T) new ByteBuddy().subclass(superType)
           .method(isDeclaredByClassHierarchy(superType))
           .intercept(MethodDelegation.to(this))
           .make()
-          .load(getSystemClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+          .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
           .getLoaded()
           .getDeclaredConstructor()
           .newInstance();


### PR DESCRIPTION
When classes are loaded dynamically the default classloader can't correctly load those classes every time and therefore the classloader of the supertype has to be used. This problem can occur for example when using Spring and mapping a proxied class.