### PR TITLE
Allow fluent setters when configured on the MappingConfiguration

### DIFF
--- a/src/main/java/com/remondis/remap/AssertConfiguration.java
+++ b/src/main/java/com/remondis/remap/AssertConfiguration.java
@@ -89,7 +89,8 @@ public class AssertConfiguration<S, D> {
   public <RS> ReassignAssertBuilder<S, D, RS> expectReassign(FieldSelector<S> sourceSelector) {
     denyNull("sourceSelector", sourceSelector);
     PropertyDescriptor sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, ASSIGN, getMapping().getSource(),
-        sourceSelector);
+        sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     ReassignAssertBuilder<S, D, RS> reassignBuilder = new ReassignAssertBuilder<S, D, RS>(sourceProperty,
         getMapping().getDestination(), this);
     return reassignBuilder;
@@ -110,9 +111,11 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RS> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE, TRANSFORM,
-        getMapping().getSource(), sourceSelector);
+        getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
 
     ReplaceAssertBuilder<S, D, RD, RS> builder = new ReplaceAssertBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -129,7 +132,8 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     SetAssertBuilder<S, D, RD> builder = new SetAssertBuilder<>(destProperty, this);
     return builder;
   }
@@ -145,7 +149,8 @@ public class AssertConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION, TRANSFORM,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     RestructureAssertBuilder<S, D, RD> builder = new RestructureAssertBuilder<>(destProperty, this);
     return builder;
   }
@@ -164,9 +169,11 @@ public class AssertConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<Collection<RS>> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, getMapping().getSource(), sourceSelector);
+        ReplaceBuilder.TRANSFORM, getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     TypedPropertyDescriptor<Collection<RD>> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, getMapping().getDestination(), destinationSelector);
+        ReplaceBuilder.TRANSFORM, getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
 
     ReplaceCollectionAssertBuilder<S, D, RD, RS> builder = new ReplaceCollectionAssertBuilder<>(sourceProperty,
         destProperty, this);
@@ -191,7 +198,8 @@ public class AssertConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     // Omit in destination
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.SOURCE, OMIT_FIELD_SOURCE,
-        getMapping().getSource(), sourceSelector);
+        getMapping().getSource(), sourceSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     OmitTransformation omitSource = omitSource(getMapping(), propertyDescriptor);
     _add(omitSource);
     return this;
@@ -235,7 +243,8 @@ public class AssertConfiguration<S, D> {
   public AssertConfiguration<S, D> expectOmitInDestination(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.DESTINATION, OMIT_FIELD_DEST,
-        getMapping().getDestination(), destinationSelector);
+        getMapping().getDestination(), destinationSelector, mapper.getMapping()
+            .isFluentSettersAllowed());
     OmitTransformation omitDestination = omitDestination(getMapping(), propertyDescriptor);
     _add(omitDestination);
     return this;

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -99,6 +99,11 @@ public class MappingConfiguration<S, D> {
    */
   private boolean writeNullIfSourceIsNull;
 
+  /**
+   * Relax strict java beans requirement about setters must have Void return type.
+   */
+  private boolean allowFluentSetters;
+
   MappingConfiguration(Class<S> source, Class<D> destination) {
     this.source = source;
     this.destination = destination;
@@ -120,7 +125,7 @@ public class MappingConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.DESTINATION, OMIT_FIELD_DEST,
-        destination, destinationSelector);
+        destination, destinationSelector, allowFluentSetters);
     OmitTransformation omitDestination = OmitTransformation.omitDestination(this, propertyDescriptor);
     omitMapping(mappedDestinationProperties, propertyDescriptor, omitDestination);
     return this;
@@ -215,7 +220,7 @@ public class MappingConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     // Omit in source
     PropertyDescriptor propertyDescriptor = getPropertyFromFieldSelector(Target.SOURCE, OMIT_FIELD_SOURCE, this.source,
-        sourceSelector);
+        sourceSelector, allowFluentSetters);
     OmitTransformation omitSource = OmitTransformation.omitSource(this, propertyDescriptor);
     omitMapping(mappedSourceProperties, propertyDescriptor, omitSource);
     return this;
@@ -231,7 +236,7 @@ public class MappingConfiguration<S, D> {
   public <RS> ReassignBuilder<S, D> reassign(FieldSelector<S> sourceSelector) {
     denyNull("sourceSelector", sourceSelector);
     PropertyDescriptor typedSourceProperty = getPropertyFromFieldSelector(Target.SOURCE, ReassignBuilder.ASSIGN,
-        this.source, sourceSelector);
+        this.source, sourceSelector, allowFluentSetters);
     ReassignBuilder<S, D> reassignBuilder = new ReassignBuilder<>(typedSourceProperty, destination, this);
     return reassignBuilder;
   }
@@ -254,9 +259,9 @@ public class MappingConfiguration<S, D> {
     denyNull("destinationSelector", destinationSelector);
 
     TypedPropertyDescriptor<RS> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, this.source, sourceSelector);
+        ReplaceBuilder.TRANSFORM, this.source, sourceSelector, allowFluentSetters);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
 
     ReplaceBuilder<S, D, RD, RS> builder = new ReplaceBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -275,7 +280,7 @@ public class MappingConfiguration<S, D> {
   public <RD> SetBuilder<S, D, RD> set(TypedSelector<RD, D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
     SetBuilder<S, D, RD> builder = new SetBuilder<>(destProperty, this);
     return builder;
   }
@@ -292,7 +297,7 @@ public class MappingConfiguration<S, D> {
   public <RD> RestructureBuilder<S, D, RD> restructure(TypedSelector<RD, D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<RD> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
     return new RestructureBuilder<S, D, RD>(this, destProperty);
   }
 
@@ -313,9 +318,9 @@ public class MappingConfiguration<S, D> {
     denyNull("sourceSelector", sourceSelector);
     denyNull("destinationSelector", destinationSelector);
     TypedPropertyDescriptor<Collection<RS>> sourceProperty = getTypedPropertyFromFieldSelector(Target.SOURCE,
-        ReplaceBuilder.TRANSFORM, this.source, sourceSelector);
+        ReplaceBuilder.TRANSFORM, this.source, sourceSelector, allowFluentSetters);
     TypedPropertyDescriptor<Collection<RD>> destProperty = getTypedPropertyFromFieldSelector(Target.DESTINATION,
-        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector);
+        ReplaceBuilder.TRANSFORM, this.destination, destinationSelector, allowFluentSetters);
 
     ReplaceCollectionBuilder<S, D, RD, RS> builder = new ReplaceCollectionBuilder<>(sourceProperty, destProperty, this);
     return builder;
@@ -485,7 +490,7 @@ public class MappingConfiguration<S, D> {
    */
   private <T> Set<PropertyDescriptor> getUnmappedProperties(Class<T> type,
       Set<PropertyDescriptor> mappedSourceProperties, Target targetType) {
-    Set<PropertyDescriptor> allSourceProperties = Properties.getProperties(type, targetType);
+    Set<PropertyDescriptor> allSourceProperties = Properties.getProperties(type, targetType, allowFluentSetters);
     allSourceProperties.removeAll(mappedSourceProperties);
     return allSourceProperties;
   }
@@ -503,7 +508,7 @@ public class MappingConfiguration<S, D> {
    * @throws MappingException if a property was specified for mapping but not invoked.
    */
   static <R, T> TypedPropertyDescriptor<R> getTypedPropertyFromFieldSelector(Target target, String configurationMethod,
-      Class<T> sensorType, TypedSelector<R, T> selector) {
+      Class<T> sensorType, TypedSelector<R, T> selector, boolean fluentSetters) {
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     T sensor = invocationSensor.getSensor();
     // perform the selector lambda on the sensor
@@ -516,7 +521,7 @@ public class MappingConfiguration<S, D> {
       // get the property name
       String propertyName = trackedPropertyNames.get(0);
       // find the property descriptor or fail with an exception
-      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName);
+      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
       TypedPropertyDescriptor<R> tpd = new TypedPropertyDescriptor<R>();
       tpd.returnValue = returnValue;
       tpd.property = property;
@@ -539,7 +544,7 @@ public class MappingConfiguration<S, D> {
    * @throws MappingException if a property was specified for mapping but not invoked.
    */
   static <T> PropertyDescriptor getPropertyFromFieldSelector(Target target, String configurationMethod,
-      Class<T> sensorType, FieldSelector<T> selector) {
+      Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     T sensor = invocationSensor.getSensor();
     // perform the selector lambda on the sensor
@@ -552,7 +557,7 @@ public class MappingConfiguration<S, D> {
       // get the property name
       String propertyName = trackedPropertyNames.get(0);
       // find the property descriptor or fail with an exception
-      return getPropertyDescriptorOrFail(target, sensorType, propertyName);
+      return getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
     } else {
       throw zeroInteractions(configurationMethod);
     }
@@ -566,9 +571,10 @@ public class MappingConfiguration<S, D> {
    * @param type The inspected type.
    * @param propertyName The property name
    */
-  static PropertyDescriptor getPropertyDescriptorOrFail(Target target, Class<?> type, String propertyName) {
+  static PropertyDescriptor getPropertyDescriptorOrFail(Target target, Class<?> type, String propertyName,
+      boolean fluentSetters) {
     Optional<PropertyDescriptor> property;
-    property = Properties.getProperties(type, target)
+    property = Properties.getProperties(type, target, fluentSetters)
         .stream()
         .filter(pd -> pd.getName()
             .equals(propertyName))
@@ -645,6 +651,21 @@ public class MappingConfiguration<S, D> {
   public MappingConfiguration<S, D> writeNullIfSourceIsNull() {
     this.writeNullIfSourceIsNull = true;
     return this;
+  }
+
+  /**
+   * Relaxes the strict java bean requirement that setters should return void, thus allowing for and mapped classes to
+   * be <em>fluent</em>.
+   * 
+   * @return Returns this object for method chaining.
+   */
+  public MappingConfiguration<S, D> allowFluentSetters() {
+    this.allowFluentSetters = true;
+    return this;
+  }
+
+  public boolean isFluentSettersAllowed() {
+    return allowFluentSetters;
   }
 
   /**

--- a/src/main/java/com/remondis/remap/MappingModel.java
+++ b/src/main/java/com/remondis/remap/MappingModel.java
@@ -77,12 +77,13 @@ public class MappingModel<S, D> {
     PropertyDescriptor destinationProperty = null;
 
     if (nonNull(sourceSelector)) {
-      sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, "findMapping", mapping.getSource(), sourceSelector);
+      sourceProperty = getPropertyFromFieldSelector(Target.SOURCE, "findMapping", mapping.getSource(), sourceSelector,
+          mapping.isFluentSettersAllowed());
     }
 
     if (nonNull(destinationSelector)) {
       destinationProperty = getPropertyFromFieldSelector(Target.DESTINATION, "findMapping", mapping.getDestination(),
-          destinationSelector);
+          destinationSelector, mapping.isFluentSettersAllowed());
     }
 
     Predicate<String> sourcePredicate = isNull(sourceProperty) ? null : nameEqualsPredicate(sourceProperty.getName());

--- a/src/main/java/com/remondis/remap/Properties.java
+++ b/src/main/java/com/remondis/remap/Properties.java
@@ -7,6 +7,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -106,13 +107,21 @@ class Properties {
    *
    * @param inspectType The type to inspect.
    * @param targetType The type of mapping target.
+   * @param fluentSetters if true, setters that return a value are allowed in the mapping.
    * @return Returns the list of {@link PropertyDescriptor}s that grant read and write access.
    * @throws MappingException Thrown on any introspection error.
    */
-  static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType) {
+  static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType, boolean fluentSetters) {
     try {
       BeanInfo beanInfo = Introspector.getBeanInfo(inspectType);
       PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
+      if (propertyDescriptors != null && fluentSetters && targetType == Target.DESTINATION) {
+        for (PropertyDescriptor pd : propertyDescriptors) {
+          if (pd.getWriteMethod() == null) {
+            checkForAndSetFluentWriteMethod(inspectType, pd);
+          }
+        }
+      }
       return new HashSet<>(Arrays.asList(propertyDescriptors)
           .stream()
           .filter(pd -> !pd.getName()
@@ -128,6 +137,26 @@ class Properties {
           .collect(Collectors.toList()));
     } catch (IntrospectionException e) {
       throw new MappingException(String.format("Cannot introspect the type %s.", inspectType.getName()));
+    }
+  }
+
+  /**
+   * Tries to see if a fluent setXXX method exists even though it was not found by the initial retrospection.
+   * If a setter exists set it as the property descriptors write method.
+   */
+  private static void checkForAndSetFluentWriteMethod(Class<?> inspectType, PropertyDescriptor pd) {
+    String writeMethodName = pd.getName();
+    writeMethodName = "set" + writeMethodName.substring(0, 1)
+        .toUpperCase() + writeMethodName.substring(1);
+    try {
+      Method setMethod = inspectType.getDeclaredMethod(writeMethodName, pd.getPropertyType());
+      if (Modifier.isPublic(setMethod.getModifiers())) {
+        pd.setWriteMethod(setMethod);
+      }
+    } catch (NoSuchMethodException e) {
+      // just ignore, the method does not have to exist
+    } catch (IntrospectionException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignAssertBuilder.java
@@ -43,7 +43,8 @@ public class ReassignAssertBuilder<S, D, RS> {
   public AssertConfiguration<S, D> to(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor destinationProperty = getPropertyFromFieldSelector(Target.DESTINATION, ReassignBuilder.ASSIGN,
-        this.destination, destinationSelector);
+        this.destination, destinationSelector, asserts.getMapping()
+            .isFluentSettersAllowed());
     ReassignTransformation transformation = new ReassignTransformation(asserts.getMapping(), sourceProperty,
         destinationProperty);
     asserts.addAssertion(transformation);

--- a/src/main/java/com/remondis/remap/ReassignBuilder.java
+++ b/src/main/java/com/remondis/remap/ReassignBuilder.java
@@ -39,7 +39,7 @@ public class ReassignBuilder<S, D> {
   public MappingConfiguration<S, D> to(FieldSelector<D> destinationSelector) {
     denyNull("destinationSelector", destinationSelector);
     PropertyDescriptor destProperty = getPropertyFromFieldSelector(Target.DESTINATION, ASSIGN, destination,
-        destinationSelector);
+        destinationSelector, mapping.isFluentSettersAllowed());
     ReassignTransformation transformation = new ReassignTransformation(mapping, sourceProperty, destProperty);
     mapping.addMapping(sourceProperty, destProperty, transformation);
     return mapping;

--- a/src/test/java/com/remondis/remap/fluent/A.java
+++ b/src/test/java/com/remondis/remap/fluent/A.java
@@ -1,0 +1,56 @@
+package com.remondis.remap.fluent;
+
+public class A {
+
+  private Integer integer;
+  private int i;
+  private String s;
+  private boolean b1;
+  private boolean b2;
+
+  public Integer getInteger() {
+    return integer;
+  }
+
+  public A setInteger(Integer integer) {
+    this.integer = integer;
+    return this;
+  }
+
+  public int getI() {
+    return integer;
+  }
+
+  public A setI(int i) {
+    this.i = i;
+    return this;
+  }
+
+  public String getS() {
+    return s;
+  }
+
+  public A setS(String s) {
+    this.s = s;
+    return this;
+  }
+
+  public boolean getB1() {
+    return b1;
+  }
+
+  public A setB1(boolean b) {
+    this.b1 = b;
+    return this;
+  }
+
+  public boolean isB2() {
+    return b2;
+  }
+
+  public A setB2(boolean b) {
+    this.b2 = b;
+    return this;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
+++ b/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
@@ -1,0 +1,34 @@
+package com.remondis.remap.fluent;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChainedSetterTest {
+
+  @Test
+  public void testChainedSetter() {
+    Mapper<A, A> m = Mapping.from(A.class)
+        .to(A.class)
+        .allowFluentSetters()
+        .mapper();
+    A expected = new A().setInteger(5)
+        .setI(22)
+        .setS("str")
+        .setB1(true)
+        .setB2(true);
+    A actual = m.map(expected);
+    assertThat(actual).isEqualToComparingFieldByField(expected);
+  }
+
+  @Test(expected = MappingException.class)
+  public void checkConfigurationOfChainedSetters() {
+    Mapping.from(A.class)
+        .to(A.class)
+        .mapper();
+  }
+
+}


### PR DESCRIPTION
Implementation attempt for #128, probably needs some tuning with regards to naming and documentation.