### PR TITLE
Update propertypath to be java 17 compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <dependency>
             <groupId>com.remondis</groupId>
             <artifactId>propertypath</artifactId>
-            <version>0.1.3</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
To be compatible with java 17 remap must use the newest propertypath version which removes cglib. cglib causes errors with java 17.