### PR TITLE
Classloader-wide proxy class caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.3.5</version>
+    <version>4.3.6</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/src/main/java/com/remondis/remap/InterceptionHandler.java
+++ b/src/main/java/com/remondis/remap/InterceptionHandler.java
@@ -1,0 +1,109 @@
+package com.remondis.remap;
+
+import static com.remondis.remap.ReflectionUtil.defaultValue;
+import static com.remondis.remap.ReflectionUtil.hasReturnType;
+import static com.remondis.remap.ReflectionUtil.invokeMethodProxySafe;
+import static com.remondis.remap.ReflectionUtil.isGetter;
+import static com.remondis.remap.ReflectionUtil.toPropertyName;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+
+public class InterceptionHandler<T> {
+
+  Class<?> type;
+
+  T proxyObject;
+
+  ThreadLocal<List<String>> threadLocalPropertyNames = new ThreadLocal<>();
+
+  /**
+   * Resets the thread local list of property names.
+   */
+  void reset() {
+    threadLocalPropertyNames.remove();
+  }
+
+  /**
+   * This method will be called each time when the object proxy calls any of its methods.
+   *
+   * @param method the intercepted method
+   * @param args the given arguments ti the intercepted method
+   * @throws Exception throws
+   */
+  @RuntimeType
+  public Object intercept(@Origin Method method, @AllArguments Object[] args) throws Exception {
+    if (isGetter(method)) {
+      denyNoReturnType(method);
+      // schuettec - Get property name from method and mark this property as called.
+      String propertyName = toPropertyName(method);
+      List<String> propertyNames = threadLocalPropertyNames.get();
+      // Lazy list creation.
+      if (isNull(propertyNames)) {
+        propertyNames = new LinkedList<>();
+        threadLocalPropertyNames.set(propertyNames);
+      }
+      propertyNames.add(propertyName);
+      // schuettec - Then return an appropriate default value.
+      return nullOrDefaultValue(method.getReturnType());
+    } else if (isObjectMethod(method)) {
+      // schuettec - 08.02.2017 : Methods like toString, equals or hashcode are redirected to this invocation
+      // handler.
+      return invokeMethodProxySafe(method, this, args);
+    } else {
+      return nullOrDefaultValue(method.getReturnType());
+    }
+  }
+
+  public void setProxyObject(T proxyObject) {
+    this.proxyObject = proxyObject;
+  }
+
+  public T getProxyObject() {
+    return proxyObject;
+  }
+
+  public List<String> getTrackesPropertyNames() {
+    List<String> list = threadLocalPropertyNames.get();
+    // Reset thread local after access.
+    reset();
+    // If list was never created (lazy-init)
+    if (isNull(list)) {
+      return Collections.emptyList();
+    } else {
+      return unmodifiableList(list);
+    }
+  }
+
+  public boolean hasTrackedProperties() {
+    return nonNull(threadLocalPropertyNames.get());
+  }
+
+  private static void denyNoReturnType(Method method) {
+    if (!hasReturnType(method)) {
+      throw MappingException.noReturnTypeOnGetter(method);
+    }
+  }
+
+  private static Object nullOrDefaultValue(Class<?> returnType) {
+    if (returnType.isPrimitive()) {
+      return defaultValue(returnType);
+    } else {
+      return null;
+    }
+  }
+
+  private static boolean isObjectMethod(Method method) {
+    return method.getDeclaringClass() == Object.class;
+  }
+
+}

--- a/src/main/java/com/remondis/remap/InterceptionHandler.java
+++ b/src/main/java/com/remondis/remap/InterceptionHandler.java
@@ -72,7 +72,7 @@ public class InterceptionHandler<T> {
     return proxyObject;
   }
 
-  public List<String> getTrackesPropertyNames() {
+  public List<String> getTrackedPropertyNames() {
     List<String> list = threadLocalPropertyNames.get();
     // Reset thread local after access.
     reset();

--- a/src/main/java/com/remondis/remap/InterceptionHandler.java
+++ b/src/main/java/com/remondis/remap/InterceptionHandler.java
@@ -20,17 +20,12 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 
 public class InterceptionHandler<T> {
 
-  Class<?> type;
-
   T proxyObject;
 
   ThreadLocal<List<String>> threadLocalPropertyNames = new ThreadLocal<>();
 
-  /**
-   * Resets the thread local list of property names.
-   */
-  void reset() {
-    threadLocalPropertyNames.remove();
+  public InterceptionHandler() {
+    super();
   }
 
   /**
@@ -82,6 +77,13 @@ public class InterceptionHandler<T> {
     } else {
       return unmodifiableList(list);
     }
+  }
+
+  /**
+   * Resets the thread local list of property names.
+   */
+  void reset() {
+    threadLocalPropertyNames.remove();
   }
 
   public boolean hasTrackedProperties() {

--- a/src/main/java/com/remondis/remap/InvocationSensor.java
+++ b/src/main/java/com/remondis/remap/InvocationSensor.java
@@ -1,23 +1,18 @@
 package com.remondis.remap;
 
-import static com.remondis.remap.ReflectionUtil.*;
 import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.util.Objects.isNull;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
-import net.bytebuddy.implementation.bind.annotation.AllArguments;
-import net.bytebuddy.implementation.bind.annotation.Origin;
-import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
@@ -28,9 +23,10 @@ import net.bytebuddy.matcher.ElementMatcher;
  */
 public class InvocationSensor<T> {
 
-  private T proxyObject;
+  private static Set<InterceptionHandler<?>> interceptionHandlerCache = new HashSet<>(); // ggf. HashSet durch etwas
+                                                                                         // thread-safes austauschen?
 
-  private List<String> propertyNames = new LinkedList<>();
+  private InterceptionHandler<T> interceptionHandler;
 
   /**
    * Creates a proxy for the given class type.
@@ -44,27 +40,31 @@ public class InvocationSensor<T> {
     } else {
       classLoader = superType.getClassLoader();
     }
-    T po = null;
     try {
-      po = (T) new ByteBuddy().subclass(superType)
+      InterceptionHandler<T> interceptionHandler = new InterceptionHandler<>();
+      T po = null;
+      po = new ByteBuddy().subclass(superType)
           .method(isDeclaredByClassHierarchy(superType))
-          .intercept(MethodDelegation.to(this))
+          .intercept(MethodDelegation.to(interceptionHandler))
           .make()
           .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
           .getLoaded()
           .getDeclaredConstructor()
           .newInstance();
+      interceptionHandler.setProxyObject(po);
+      interceptionHandlerCache.add(interceptionHandler);
+      this.interceptionHandler = interceptionHandler;
+
     } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
       throw new MappingException(
           String.format("Error while creating proxy for class '%s'", superType.getCanonicalName()), ex);
     }
-    proxyObject = po;
   }
 
   /**
    * Creates an {@link ElementMatcher.Junction} for the method description of all superclasses, interfaces and the given
    * type itself so that all of those methods are proxied by the {@link InvocationSensor}.
-   * 
+   *
    * @param type type to get the junction for
    * @return the junction with all superclasses and interfaces including the given typeD
    */
@@ -83,37 +83,12 @@ public class InvocationSensor<T> {
   }
 
   /**
-   * This method will be called each time when the object proxy calls any of its methods.
-   *
-   * @param method the intercepted method
-   * @param args the given arguments ti the intercepted method
-   * @throws Exception throws
-   */
-  @RuntimeType
-  public Object intercept(@Origin Method method, @AllArguments Object[] args) throws Exception {
-    if (isGetter(method)) {
-      denyNoReturnType(method);
-      // schuettec - Get property name from method and mark this property as called.
-      String propertyName = toPropertyName(method);
-      propertyNames.add(propertyName);
-      // schuettec - Then return an appropriate default value.
-      return nullOrDefaultValue(method.getReturnType());
-    } else if (isObjectMethod(method)) {
-      // schuettec - 08.02.2017 : Methods like toString, equals or hashcode are redirected to this invocation
-      // handler.
-      return invokeMethodProxySafe(method, this, args);
-    } else {
-      return nullOrDefaultValue(method.getReturnType());
-    }
-  }
-
-  /**
    * Returns the proxy object get-method calls can be performed on.
    *
    * @return The proxy.
    */
   T getSensor() {
-    return proxyObject;
+    return interceptionHandler.getProxyObject();
   }
 
   /**
@@ -122,7 +97,8 @@ public class InvocationSensor<T> {
    * @return Returns the tracked property names.
    */
   List<String> getTrackedPropertyNames() {
-    return Collections.unmodifiableList(propertyNames);
+    List<String> trackesPropertyNames = interceptionHandler.getTrackesPropertyNames();
+    return trackesPropertyNames;
   }
 
   /**
@@ -132,32 +108,8 @@ public class InvocationSensor<T> {
    *         <code>false</code> is returned.
    */
   boolean hasTrackedProperties() {
-    return !propertyNames.isEmpty();
-  }
-
-  /**
-   * Resets all tracked information.
-   */
-  void reset() {
-    propertyNames.clear();
-  }
-
-  private void denyNoReturnType(Method method) {
-    if (!hasReturnType(method)) {
-      throw MappingException.noReturnTypeOnGetter(method);
-    }
-  }
-
-  private static Object nullOrDefaultValue(Class<?> returnType) {
-    if (returnType.isPrimitive()) {
-      return defaultValue(returnType);
-    } else {
-      return null;
-    }
-  }
-
-  private static boolean isObjectMethod(Method method) {
-    return method.getDeclaringClass() == Object.class;
+    boolean hasTrackedProperties = interceptionHandler.hasTrackedProperties();
+    return hasTrackedProperties;
   }
 
 }

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -539,7 +539,6 @@ public class MappingConfiguration<S, D> {
   static <R, T> TypedPropertyDescriptor<R> getTypedPropertyFromFieldSelector(InvocationSensor<?> invocationSensor,
       Target target, String configurationMethod, Class<T> sensorType, TypedSelector<R, T> selector,
       boolean fluentSetters) {
-    invocationSensor.reset();
     T sensor = (T) invocationSensor.getSensor();
     // perform the selector lambda on the sensor
     R returnValue = selector.selectField(sensor);
@@ -582,7 +581,6 @@ public class MappingConfiguration<S, D> {
 
   static <T> PropertyDescriptor getPropertyFromFieldSelector(InvocationSensor<?> invocationSensor, Target target,
       String configurationMethod, Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
-    invocationSensor.reset();
     T sensor = (T) invocationSensor.getSensor();
     // perform the selector lambda on the sensor
     selector.selectField(sensor);
@@ -684,7 +682,7 @@ public class MappingConfiguration<S, D> {
    * mapping if the source value is <code>null</code>.
    *
    * @return Returns this {@link MappingConfiguration} object for further configuration.
-   * 
+   *
    * @deprecated This method is deprecated, because the map-into feature of ReMap is not correctly implemented and will
    *             be removed in future release.
    */

--- a/src/test/java/com/remondis/remap/DummyDto.java
+++ b/src/test/java/com/remondis/remap/DummyDto.java
@@ -1,0 +1,58 @@
+package com.remondis.remap;
+
+import java.util.Objects;
+
+public class DummyDto {
+
+  private String string;
+
+  private String anotherString;
+
+  public DummyDto(String string, String anotherString) {
+    super();
+    this.string = string;
+    this.anotherString = anotherString;
+  }
+
+  public DummyDto() {
+    super();
+  }
+
+  public String getAnotherString() {
+    return anotherString;
+  }
+
+  public void setAnotherString(String anotherString) {
+    this.anotherString = anotherString;
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(anotherString, string);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DummyDto other = (DummyDto) obj;
+    return Objects.equals(anotherString, other.anotherString) && Objects.equals(string, other.string);
+  }
+
+  @Override
+  public String toString() {
+    return "DummyDto [string=" + string + ", anotherString=" + anotherString + "]";
+  }
+}

--- a/src/test/java/com/remondis/remap/InvocationSensorTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorTest.java
@@ -1,0 +1,84 @@
+package com.remondis.remap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class InvocationSensorTest {
+
+  @Before
+  public void setup() {
+    InvocationSensor.interceptionHandlerCache.clear();
+  }
+
+  @Test
+  public void shouldCacheThreadSafe() {
+
+    Semaphore s1 = new Semaphore(1);
+    s1.acquireUninterruptibly();
+
+    Semaphore s2 = new Semaphore(1);
+    s2.acquireUninterruptibly();
+
+    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(DummyDto.class);
+
+    Thread t1 = new Thread(new Runnable() {
+
+      @Override
+      public void run() {
+        InvocationSensor<DummyDto> invocationSensor = new InvocationSensor<>(DummyDto.class);
+        DummyDto sensor = invocationSensor.getSensor();
+        sensor.getString();
+        s2.release();
+        s1.acquireUninterruptibly();
+      }
+    });
+    t1.start();
+
+    // Hier warte bis t1 mindestens getString() aufgerufen hast
+    s2.acquireUninterruptibly();
+    InvocationSensor<DummyDto> invocationSensor = new InvocationSensor<>(DummyDto.class);
+    List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
+    assertTrue(trackedPropertyNames.isEmpty());
+    s1.release();
+  }
+
+  @Test
+  public void shouldCache() {
+    assertTrue(InvocationSensor.interceptionHandlerCache.isEmpty());
+    InvocationSensor<DummyDto> invocationSensor = new InvocationSensor<>(DummyDto.class);
+    assertFalse(InvocationSensor.interceptionHandlerCache.isEmpty());
+    assertTrue(InvocationSensor.interceptionHandlerCache.containsKey(DummyDto.class));
+    assertNotNull(InvocationSensor.interceptionHandlerCache.get(DummyDto.class));
+
+    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(DummyDto.class);
+
+    DummyDto sensor = invocationSensor.getSensor();
+    sensor.getString();
+
+    List<String> trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(1, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("string"));
+
+    sensor.getAnotherString();
+    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(1, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("anotherString"));
+
+    sensor.getString();
+    sensor.getAnotherString();
+    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(2, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("string"));
+    assertTrue(trackedPropertyNames.contains("anotherString"));
+
+  }
+
+}


### PR DESCRIPTION
The use of byte buddy let to a potential memory leak due to non-cached proxy classes. 
ReMap was extended to support proxy class caching while being thread-safe.