### PR TITLE
Add aggregated mapper validation to show all ReMap configuration errors at once

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Finsh package
+	    run: |
+	      curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" \
+	           -X POST \
+	           https://central.sonatype.com/manual/upload/defaultRepository/com.remondis

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,12 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Finsh package
-	    run:  curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" -X POST https://central.sonatype.com/manual/upload/defaultRepository/com.remondis
+        run:  curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" -X POST https://central.sonatype.com/manual/upload/defaultRepository/com.remondis

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,4 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
       - name: Finsh package
-	    run: |
-	      curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" \
-	           -X POST \
-	           https://central.sonatype.com/manual/upload/defaultRepository/com.remondis
+	    run:  curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" -X POST https://central.sonatype.com/manual/upload/defaultRepository/com.remondis

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Finsh package
-        run:  curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" -X POST https://central.sonatype.com/manual/upload/defaultRepository/com.remondis
+        run:  curl -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.remondis

--- a/README.md
+++ b/README.md
@@ -769,6 +769,10 @@ This workaround was tested and should work for most cases. Please file an issue 
 
 # Migration guide
 
+## Sidenote for 4.4.3
+- Added **aggregated validation support** for all ReMap mappers.  
+  Instead of failing on the first invalid mapper, ReMap now collects all `MappingException`s during initialization and throws a single aggregated error after all mappers are created.
+
 ## Sidenote for 4.4.2
 - Improved `MappingException` messages for collections containing `null` elements. The exception now includes the specific field name (e.g., `stringList`) and source/destination types, making debugging easier.
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <repository>
             <id>ossrh</id>
             <name>Central Repository OSSRH</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>remap</artifactId>
-    <version>4.4.2</version>
+    <version>4.4.3</version>
     <packaging>jar</packaging>
     <name>ReMap</name>
     <description>A declarative mapping library for converting objects field by field.</description>

--- a/src/main/java/com/remondis/remap/Mapper.java
+++ b/src/main/java/com/remondis/remap/Mapper.java
@@ -1,6 +1,9 @@
 package com.remondis.remap;
 
+import org.springframework.beans.factory.SmartInitializingSingleton;
+
 import static com.remondis.remap.ReflectionUtil.getCollector;
+import static com.remondis.remap.ValidationAggregator.throwIfAnyAndClear;
 import static java.util.Objects.isNull;
 
 import java.util.Collection;
@@ -17,7 +20,7 @@ import java.util.stream.StreamSupport;
  * @param <D> The destination type
  * @author schuettec
  */
-public class Mapper<S, D> {
+public class Mapper<S, D> implements SmartInitializingSingleton {
 
   private MappingConfiguration<S, D> mapping;
 
@@ -148,4 +151,8 @@ public class Mapper<S, D> {
     return new MappingModel<>(getMapping());
   }
 
+  @Override
+  public void afterSingletonsInstantiated() {
+    throwIfAnyAndClear();
+  }
 }

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -398,7 +398,11 @@ public class MappingConfiguration<S, D> {
       addOmitForDestination();
     }
 
-    validateMapping();
+    try {
+      validateMapping();
+    } catch (MappingException ex) {
+      ValidationAggregator.add(source, destination, ex);
+    }
     sourceInvocationSensor = null;
     destinationInvocationSensor = null;
     return new Mapper<>(this);

--- a/src/main/java/com/remondis/remap/ValidationAggregator.java
+++ b/src/main/java/com/remondis/remap/ValidationAggregator.java
@@ -1,0 +1,28 @@
+package com.remondis.remap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class ValidationAggregator {
+
+  private static final List<RuntimeException> PROBLEMS = new ArrayList<>();
+
+  private ValidationAggregator() {
+  }
+
+  static void add(Class<?> source, Class<?> destination, MappingException cause) {
+    String msg = "Mapping " + source.getSimpleName() + " -> " + destination.getSimpleName() + " failed:\n"
+        + cause.getMessage();
+    MappingException perMapper = new MappingException(msg, cause);
+    PROBLEMS.add(perMapper);
+  }
+
+  static void throwIfAnyAndClear() {
+    if (PROBLEMS.isEmpty())
+      return;
+    IllegalStateException aggregated = new IllegalStateException("ReMap aggregated validation failed");
+    PROBLEMS.forEach(aggregated::addSuppressed);
+    PROBLEMS.clear();
+    throw aggregated;
+  }
+}


### PR DESCRIPTION
Added aggregated mapper validation in ReMap.
Instead of failing on the first error, all mapping validation errors are now collected and thrown together as a single exception with suppressed exceptions.
This allows developers to see all invalid mappers at once and fix all issues in one go.