### PR TITLE
feat: add Java Record mapping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
    10. [Mapping other values to a field](#mapping-other-values-to-a-field)
    11. [Restructure a complex object in the destination](#restructure-a-complex-object-in-the-destination)
    12. [Mapping maps](#mapping-maps)
-   13. [Tests](#tests)
+   13. [Mapping Java Records](#mapping-java-records)
+   14. [Tests](#tests)
 9. [Mapping meta model](#mapping-meta-model)
 10. [Spring integration](#spring-integration)
    1. [Spring Boot Issue](#spring-boot-issue)
@@ -71,6 +72,10 @@ ReMap maps a objects of a source to a destination type. As per default ReMap tri
 
 
 ## News
+
+### Java Record mapping support
+
+ReMap now supports Java Records as both source and destination types. Records can be mapped to/from regular POJOs as well as to/from other records — using the same familiar API. See [Mapping Java Records](#mapping-java-records) in the cookbook for details and examples.
 
 ### Map into feature deprecated!
 The map-into feature of ReMap is now deprecated. This function was never correctly implemented and does not work recursively.
@@ -189,6 +194,7 @@ ReMap supports
 * mapping from interface to Java Bean type
 * mapping of nested collections
 * mapping of nested maps
+* mapping of Java Records as source and/or destination type (POJO↔Record, Record↔Record)
 * unit testing of mapping specifications
 * mapping without invasively changing code of involved objects
 * overwrite fields in an instance by specifying the target instance for the mapping
@@ -209,6 +215,7 @@ ReMap supports
 * mapping equal types does not copy object instances!
 * multi-classloader environments are currently not supported. All types must be loaded by the same classloader.
 * Generics cannot be used without limitations: It is possible to build a mapper for generic types, but due to the class literals used when declaring the mapping, the generic type informations gets lost.
+* when a Java Record is the **destination** type, the `map(S source, D dest)` overwrite-in-place method is not supported because records are immutable — an `UnsupportedOperationException` is thrown at runtime.
 
 ## The mapping cookbook
 
@@ -631,6 +638,148 @@ if the following mappers were registered on the mapping:
 - `A2` to `A2Mapped`
 - `A3` to `A3Mapped`
 
+
+### Mapping Java Records
+
+ReMap supports Java Records (introduced in Java 14) as both source and destination types. All the usual mapping operations (`reassign`, `replace`, `omitInSource`, `omitInDestination`, `useMapper`, …) work transparently for records. Because records are immutable, ReMap automatically constructs the destination record via its canonical constructor instead of using setter methods.
+
+> **Note:** The `map(S source, D destination)` overwrite-in-place variant is **not** supported when the destination is a record — records are immutable and cannot be modified after construction. An `UnsupportedOperationException` is thrown if you attempt this.
+
+#### POJO → Record (implicit)
+
+When field names match, no additional configuration is needed:
+
+```java
+public class PersonPojo {
+  private String name;
+  private int age;
+  // default constructor, getters, setters …
+}
+
+public record PersonRecord(String name, int age) {}
+
+Mapper<PersonPojo, PersonRecord> mapper = Mapping
+    .from(PersonPojo.class)
+    .to(PersonRecord.class)
+    .mapper();
+
+PersonRecord result = mapper.map(new PersonPojo("Alice", 30));
+// result.name() == "Alice", result.age() == 30
+```
+
+#### POJO → Record (with reassign)
+
+Use `reassign` when source and destination field names differ:
+
+```java
+public record PersonResourceRecord(String fullName, int yearsOld, String emailAddress) {}
+
+Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping
+    .from(PersonPojo.class)
+    .to(PersonResourceRecord.class)
+    .reassign(PersonPojo::getName).to(PersonResourceRecord::fullName)
+    .reassign(PersonPojo::getAge).to(PersonResourceRecord::yearsOld)
+    .reassign(PersonPojo::getEmail).to(PersonResourceRecord::emailAddress)
+    .mapper();
+```
+
+#### POJO → Record (with replace)
+
+Use `replace` to transform a value while mapping it:
+
+```java
+Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping
+    .from(PersonPojo.class)
+    .to(PersonResourceRecord.class)
+    .replace(PersonPojo::getName, PersonResourceRecord::fullName)
+        .with(name -> name.toUpperCase())
+    .reassign(PersonPojo::getAge).to(PersonResourceRecord::yearsOld)
+    .reassign(PersonPojo::getEmail).to(PersonResourceRecord::emailAddress)
+    .mapper();
+```
+
+#### Record → POJO (implicit)
+
+Records can also be used as the **source** type:
+
+```java
+Mapper<PersonRecord, PersonPojo> mapper = Mapping
+    .from(PersonRecord.class)
+    .to(PersonPojo.class)
+    .mapper();
+
+PersonPojo result = mapper.map(new PersonRecord("Diana", 28, "diana@example.com", false));
+```
+
+#### Record → Record
+
+Mapping between two record types works exactly the same way:
+
+```java
+Mapper<PersonRecord, PersonResourceRecord> mapper = Mapping
+    .from(PersonRecord.class)
+    .to(PersonResourceRecord.class)
+    .reassign(PersonRecord::name).to(PersonResourceRecord::fullName)
+    .reassign(PersonRecord::age).to(PersonResourceRecord::yearsOld)
+    .reassign(PersonRecord::email).to(PersonResourceRecord::emailAddress)
+    .mapper();
+```
+
+#### Nested records with useMapper
+
+Use `useMapper` to map nested record fields, just as you would for POJOs:
+
+```java
+public record AddressRecord(String street, String city) {}
+public record PersonWithAddressRecord(String name, AddressRecord address) {}
+
+Mapper<AddressPojo, AddressRecord> addressMapper = Mapping
+    .from(AddressPojo.class)
+    .to(AddressRecord.class)
+    .mapper();
+
+Mapper<PersonWithAddressPojo, PersonWithAddressRecord> mapper = Mapping
+    .from(PersonWithAddressPojo.class)
+    .to(PersonWithAddressRecord.class)
+    .useMapper(addressMapper)
+    .mapper();
+```
+
+#### Omitting fields
+
+`omitInSource` and `omitInDestination` work normally. When a record component is omitted as destination, its value in the constructed record will be `null` (for reference types) or the zero-value for primitive types:
+
+```java
+Mapper<PersonPojo, PersonRecord> mapper = Mapping
+    .from(PersonPojo.class)
+    .to(PersonRecord.class)
+    .omitInSource(PersonPojo::getEmail)
+    .omitInDestination(PersonRecord::email)
+    .mapper();
+// result.email() == null
+```
+
+#### Collection mapping
+
+Mapping collections of records works out of the box:
+
+```java
+List<PersonRecord> results = mapper.map(listOfPersonPojos);
+```
+
+#### Testing record mappings
+
+Use `AssertMapping` exactly as for POJO-based mappers:
+
+```java
+AssertMapping.of(mapper)
+    .expectReassign(PersonRecord::name).to(PersonResourceRecord::fullName)
+    .expectReassign(PersonRecord::age).to(PersonResourceRecord::yearsOld)
+    .expectReassign(PersonRecord::email).to(PersonResourceRecord::emailAddress)
+    .ensure();
+```
+
+You can find all record mapping test cases [here](src/test/java/com/remondis/remap/records/RecordMappingTest.java).
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ ReMap supports
 * mapping equal types does not copy object instances!
 * multi-classloader environments are currently not supported. All types must be loaded by the same classloader.
 * Generics cannot be used without limitations: It is possible to build a mapper for generic types, but due to the class literals used when declaring the mapping, the generic type informations gets lost.
-* when a Java Record is the **destination** type, the `map(S source, D dest)` overwrite-in-place method is not supported because records are immutable — an `UnsupportedOperationException` is thrown at runtime.
+* when a Java Record is the **destination** type, the `map(S source, D dest)` overwrite-in-place method returns a **new record instance** because records are immutable. The component values of the specified destination record are used as defaults for all fields not covered by the mapping.
 
 ## The mapping cookbook
 
@@ -643,7 +643,9 @@ if the following mappers were registered on the mapping:
 
 ReMap supports Java Records (introduced in Java 14) as both source and destination types. All the usual mapping operations (`reassign`, `replace`, `omitInSource`, `omitInDestination`, `useMapper`, …) work transparently for records. Because records are immutable, ReMap automatically constructs the destination record via its canonical constructor instead of using setter methods.
 
-> **Note:** The `map(S source, D destination)` overwrite-in-place variant is **not** supported when the destination is a record — records are immutable and cannot be modified after construction. An `UnsupportedOperationException` is thrown if you attempt this.
+> **Note:** Since records are immutable, the `map(S source, D destination)` overwrite-in-place variant cannot modify the specified destination record. Instead it returns a **new record instance**: the component values of the given destination record serve as defaults for all fields that are not covered by the mapping (for example omitted fields), while all mapped fields are taken from the source. Make sure to use the returned instance instead of the passed destination object.
+>
+> **Note:** Property selectors for record types must be **method references** (e.g. `PersonRecord::name`). Inline lambdas (e.g. `r -> r.name()`) cannot be analyzed for records and are rejected with a `MappingException` when the mapping is configured.
 
 #### POJO → Record (implicit)
 

--- a/src/main/java/com/remondis/remap/FieldSelector.java
+++ b/src/main/java/com/remondis/remap/FieldSelector.java
@@ -11,7 +11,7 @@ package com.remondis.remap;
  * @author schuettec
  */
 @FunctionalInterface
-public interface FieldSelector<T> {
+public interface FieldSelector<T> extends java.io.Serializable {
 
   /**
    * This method is used to perform a get-method invocation of the specified destination object. This invocation tells

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -10,11 +10,16 @@ import static com.remondis.remap.ReflectionUtil.newInstance;
 import static java.util.Objects.nonNull;
 
 import java.beans.PropertyDescriptor;
+import java.io.Serializable;
+import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -131,14 +136,14 @@ public class MappingConfiguration<S, D> {
   }
 
   private InvocationSensor<?> getSourceInvocationSensor() {
-    if (sourceInvocationSensor == null) {
+    if (sourceInvocationSensor == null && !source.isRecord()) {
       this.sourceInvocationSensor = new InvocationSensor<>(source);
     }
     return sourceInvocationSensor;
   }
 
   private InvocationSensor<?> getDestinationeInvocationSensor() {
-    if (destinationInvocationSensor == null) {
+    if (destinationInvocationSensor == null && !destination.isRecord()) {
       this.destinationInvocationSensor = new InvocationSensor<>(destination);
     }
     return destinationInvocationSensor;
@@ -544,6 +549,9 @@ public class MappingConfiguration<S, D> {
    */
   static <R, T> TypedPropertyDescriptor<R> getTypedPropertyFromFieldSelector(Target target, String configurationMethod,
       Class<T> sensorType, TypedSelector<R, T> selector, boolean fluentSetters) {
+    if (sensorType.isRecord()) {
+      return getTypedPropertyFromFieldSelector(null, target, configurationMethod, sensorType, selector, fluentSetters);
+    }
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     return getTypedPropertyFromFieldSelector(invocationSensor, target, configurationMethod, sensorType, selector,
         fluentSetters);
@@ -552,6 +560,15 @@ public class MappingConfiguration<S, D> {
   static <R, T> TypedPropertyDescriptor<R> getTypedPropertyFromFieldSelector(InvocationSensor<?> invocationSensor,
       Target target, String configurationMethod, Class<T> sensorType, TypedSelector<R, T> selector,
       boolean fluentSetters) {
+    // For records, use SerializedLambda to extract the method name
+    if (sensorType.isRecord()) {
+      String propertyName = extractPropertyNameFromLambda(selector, sensorType);
+      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
+      TypedPropertyDescriptor<R> tpd = new TypedPropertyDescriptor<R>();
+      tpd.returnValue = null;
+      tpd.property = property;
+      return tpd;
+    }
     T sensor = (T) invocationSensor.getSensor();
     // Defensively reset the tracking state: a previously failed selector invocation may have left tracked
     // properties on this thread which would corrupt the evaluation of this selector.
@@ -594,6 +611,9 @@ public class MappingConfiguration<S, D> {
    */
   static <T> PropertyDescriptor getPropertyFromFieldSelector(Target target, String configurationMethod,
       Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
+    if (sensorType.isRecord()) {
+      return getPropertyFromFieldSelector(null, target, configurationMethod, sensorType, selector, fluentSetters);
+    }
     InvocationSensor<T> invocationSensor = new InvocationSensor<T>(sensorType);
     return getPropertyFromFieldSelector(invocationSensor, target, configurationMethod, sensorType, selector,
         fluentSetters);
@@ -601,6 +621,11 @@ public class MappingConfiguration<S, D> {
 
   static <T> PropertyDescriptor getPropertyFromFieldSelector(InvocationSensor<?> invocationSensor, Target target,
       String configurationMethod, Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
+    // For records, use SerializedLambda to extract the method name
+    if (sensorType.isRecord()) {
+      String propertyName = extractPropertyNameFromLambda(selector, sensorType);
+      return getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
+    }
     T sensor = (T) invocationSensor.getSensor();
     // Defensively reset the tracking state: a previously failed selector invocation may have left tracked
     // properties on this thread which would corrupt the evaluation of this selector.
@@ -652,6 +677,42 @@ public class MappingConfiguration<S, D> {
   static void denyMultipleInteractions(String configurationMethod, List<String> trackedPropertyNames) {
     if (trackedPropertyNames.size() > 1) {
       throw multipleInteractions(configurationMethod, trackedPropertyNames);
+    }
+  }
+
+  /**
+   * Extracts the property name from a serializable lambda (method reference) using {@link SerializedLambda}.
+   * This is used for record types where ByteBuddy proxying is not possible.
+   *
+   * @param lambda The serializable lambda (method reference like {@code MyRecord::name}).
+   * @param type The record type for error messages.
+   * @return The property name referenced by the lambda.
+   */
+  static <T> String extractPropertyNameFromLambda(Serializable lambda, Class<T> type) {
+    try {
+      Method writeReplace = lambda.getClass()
+          .getDeclaredMethod("writeReplace");
+      writeReplace.setAccessible(true);
+      SerializedLambda sl = (SerializedLambda) writeReplace.invoke(lambda);
+      String methodName = sl.getImplMethodName();
+
+      // For record accessors, the method name IS the property name (e.g., "isActive" for isActive())
+      if (type.isRecord()) {
+        return methodName;
+      }
+
+      // For JavaBeans-style getters, strip get/is prefix
+      if (methodName.startsWith("get") && methodName.length() > 3) {
+        return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+      } else if (methodName.startsWith("is") && methodName.length() > 2) {
+        return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+      }
+      return methodName;
+    } catch (Exception e) {
+      throw new MappingException(String.format(
+          "Cannot extract property name from method reference for record type %s. "
+              + "Only method references (e.g., MyRecord::name) are supported for record types, not inline lambdas.",
+          type.getName()), e);
     }
   }
 
@@ -815,10 +876,17 @@ public class MappingConfiguration<S, D> {
    * @return Returns a newly created destination object.
    */
   D map(S source, D destination) {
-    D destinationObject = destination;
     if (source == null) {
       throw MappingException.denyMappingOfNull();
     }
+    if (this.destination.isRecord()) {
+      if (destination != null) {
+        throw new UnsupportedOperationException(
+            "Cannot map into an existing record instance. Records are immutable. Use map(source) instead.");
+      }
+      return mapToRecord(source);
+    }
+    D destinationObject = destination;
     if (destination == null) {
       destinationObject = createDestination();
     }
@@ -826,6 +894,59 @@ public class MappingConfiguration<S, D> {
       t.performTransformation(source, destinationObject);
     }
     return destinationObject;
+  }
+
+  /**
+   * Maps the source object to a new record instance by collecting all transformation values and invoking
+   * the canonical constructor.
+   */
+  @SuppressWarnings("unchecked")
+  private D mapToRecord(S source) {
+    RecordComponent[] components = destination.getRecordComponents();
+    Map<String, Object> values = new LinkedHashMap<>();
+
+    // Initialize with default values for primitives, null for objects
+    for (RecordComponent component : components) {
+      if (component.getType()
+          .isPrimitive()) {
+        values.put(component.getName(), ReflectionUtil.defaultValue(component.getType()));
+      } else {
+        values.put(component.getName(), null);
+      }
+    }
+
+    // Collect values from all transformations
+    for (Transformation t : mappings) {
+      if (t instanceof OmitTransformation) {
+        continue;
+      }
+
+      String destPropName = t.getDestinationPropertyName();
+      if (destPropName == null) {
+        continue;
+      }
+
+      MappedResult result = t.computeValue(source);
+
+      if (result.hasValue()) {
+        values.put(destPropName, result.getValue());
+      }
+    }
+
+    // Invoke the canonical constructor
+    try {
+      Class<?>[] paramTypes = new Class<?>[components.length];
+      Object[] args = new Object[components.length];
+      for (int i = 0; i < components.length; i++) {
+        paramTypes[i] = components[i].getType();
+        args[i] = values.get(components[i].getName());
+      }
+      Constructor<D> ctor = destination.getDeclaredConstructor(paramTypes);
+      ctor.setAccessible(true);
+      return ctor.newInstance(args);
+    } catch (Exception e) {
+      throw MappingException.newInstanceFailed(destination, e);
+    }
   }
 
   private D createDestination() {

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -887,11 +887,7 @@ public class MappingConfiguration<S, D> {
       throw MappingException.denyMappingOfNull();
     }
     if (this.destination.isRecord()) {
-      if (destination != null) {
-        throw new UnsupportedOperationException(
-            "Cannot map into an existing record instance. Records are immutable. Use map(source) instead.");
-      }
-      return mapToRecord(source);
+      return mapToRecord(source, destination);
     }
     D destinationObject = destination;
     if (destination == null) {
@@ -905,16 +901,28 @@ public class MappingConfiguration<S, D> {
 
   /**
    * Maps the source object to a new record instance by collecting all transformation values and invoking
-   * the canonical constructor.
+   * the canonical constructor. If an existing record is provided, its component values are used as defaults
+   * so that unmapped/omitted fields retain their original values.
+   *
+   * @param source The source object.
+   * @param existingRecord An optional existing record whose values serve as defaults. May be {@code null}.
    */
   @SuppressWarnings("unchecked")
-  private D mapToRecord(S source) {
+  private D mapToRecord(S source, D existingRecord) {
     RecordComponent[] components = destination.getRecordComponents();
     Map<String, Object> values = new LinkedHashMap<>();
 
-    // Initialize with default values for primitives, null for objects
+    // Initialize values: from existing record if provided, otherwise defaults
     for (RecordComponent component : components) {
-      if (component.getType()
+      if (existingRecord != null) {
+        try {
+          values.put(component.getName(), component.getAccessor()
+              .invoke(existingRecord));
+        } catch (Exception e) {
+          throw new MappingException(String.format("Could not read record component '%s' from %s.", component.getName(),
+              destination.getSimpleName()), e);
+        }
+      } else if (component.getType()
           .isPrimitive()) {
         values.put(component.getName(), ReflectionUtil.defaultValue(component.getType()));
       } else {

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -696,31 +696,44 @@ public class MappingConfiguration<S, D> {
    * @return The property name referenced by the lambda.
    */
   static <T> String extractPropertyNameFromLambda(Serializable lambda, Class<T> type) {
+    String methodName;
     try {
       Method writeReplace = lambda.getClass()
           .getDeclaredMethod("writeReplace");
       writeReplace.setAccessible(true);
       SerializedLambda sl = (SerializedLambda) writeReplace.invoke(lambda);
-      String methodName = sl.getImplMethodName();
-
-      // For record accessors, the method name IS the property name (e.g., "isActive" for isActive())
-      if (type.isRecord()) {
-        return methodName;
-      }
-
-      // For JavaBeans-style getters, strip get/is prefix
-      if (methodName.startsWith("get") && methodName.length() > 3) {
-        return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
-      } else if (methodName.startsWith("is") && methodName.length() > 2) {
-        return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
-      }
-      return methodName;
+      methodName = sl.getImplMethodName();
     } catch (Exception e) {
       throw new MappingException(String.format(
           "Cannot extract property name from method reference for record type %s. "
               + "Only method references (e.g., MyRecord::name) are supported for record types, not inline lambdas.",
           type.getName()), e);
     }
+
+    /*
+     * An inline lambda (e.g. r -> r.name()) compiles to a synthetic method, so the referenced property cannot be
+     * identified. Detect this here to fail with a clear message instead of reporting the synthetic method name as an
+     * unknown property.
+     */
+    if (methodName.startsWith("lambda$")) {
+      throw new MappingException(String.format(
+          "Cannot extract property name from an inline lambda for record type %s. "
+              + "Only method references (e.g. %s::componentName) are supported for record types.",
+          type.getName(), type.getSimpleName()));
+    }
+
+    // For record accessors, the method name IS the property name (e.g., "isActive" for isActive())
+    if (type.isRecord()) {
+      return methodName;
+    }
+
+    // For JavaBeans-style getters, strip get/is prefix
+    if (methodName.startsWith("get") && methodName.length() > 3) {
+      return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+    } else if (methodName.startsWith("is") && methodName.length() > 2) {
+      return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+    }
+    return methodName;
   }
 
   static void denyAlreadyMappedProperty(Set<PropertyDescriptor> mappedProperties,

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -121,6 +121,13 @@ public class MappingConfiguration<S, D> {
    */
   private volatile Constructor<D> destinationConstructor;
 
+  /**
+   * Caches the canonical constructor of a record destination type. Resolved on the first mapping to avoid the
+   * reflective lookup for every mapped object. Volatile for safe publication when the mapper is shared between
+   * threads.
+   */
+  private volatile Constructor<D> recordConstructor;
+
   MappingConfiguration(Class<S> source, Class<D> destination) {
     this.source = source;
     this.destination = destination;
@@ -934,19 +941,39 @@ public class MappingConfiguration<S, D> {
     }
 
     // Invoke the canonical constructor
+    Constructor<D> constructor = canonicalRecordConstructor(components);
     try {
-      Class<?>[] paramTypes = new Class<?>[components.length];
       Object[] args = new Object[components.length];
       for (int i = 0; i < components.length; i++) {
-        paramTypes[i] = components[i].getType();
         args[i] = values.get(components[i].getName());
       }
-      Constructor<D> ctor = destination.getDeclaredConstructor(paramTypes);
-      ctor.setAccessible(true);
-      return ctor.newInstance(args);
+      return constructor.newInstance(args);
     } catch (Exception e) {
       throw MappingException.newInstanceFailed(destination, e);
     }
+  }
+
+  /**
+   * Returns the canonical constructor of the record destination type. The constructor is resolved once on the first
+   * mapping, analogous to {@link #createDestination()}.
+   */
+  private Constructor<D> canonicalRecordConstructor(RecordComponent[] components) {
+    Constructor<D> constructor = recordConstructor;
+    if (constructor == null) {
+      // Benign race: concurrent first mappings may resolve the constructor multiple times with the same result.
+      Class<?>[] paramTypes = new Class<?>[components.length];
+      for (int i = 0; i < components.length; i++) {
+        paramTypes[i] = components[i].getType();
+      }
+      try {
+        constructor = destination.getDeclaredConstructor(paramTypes);
+        constructor.setAccessible(true);
+      } catch (Exception e) {
+        throw MappingException.newInstanceFailed(destination, e);
+      }
+      recordConstructor = constructor;
+    }
+    return constructor;
   }
 
   private D createDestination() {

--- a/src/main/java/com/remondis/remap/Properties.java
+++ b/src/main/java/com/remondis/remap/Properties.java
@@ -11,9 +11,11 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -119,12 +121,36 @@ class Properties {
    */
   static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType, boolean fluentSetters) {
     try {
+      if (inspectType.isRecord()) {
+        return extractRecordProperties(inspectType, targetType);
+      }
       Set<PropertyDescriptor> result = extractBaseProperties(inspectType, targetType, fluentSetters);
       mergeInterfaceProperties(inspectType, targetType, result);
       return result;
     } catch (IntrospectionException e) {
       throw new MappingException(String.format("Cannot introspect the type %s.", inspectType.getName()));
     }
+  }
+
+  /**
+   * Extracts properties from a Java Record using its record components.
+   * Record accessors (e.g., {@code name()}) are used as read methods.
+   * Records have no write methods (immutable).
+   * For destination records, properties are returned without requiring a setter.
+   */
+  private static Set<PropertyDescriptor> extractRecordProperties(Class<?> recordType, Target targetType) {
+    RecordComponent[] components = recordType.getRecordComponents();
+    Set<PropertyDescriptor> result = new HashSet<>();
+    for (RecordComponent component : components) {
+      try {
+        PropertyDescriptor pd = new PropertyDescriptor(component.getName(), component.getAccessor(), null);
+        result.add(pd);
+      } catch (IntrospectionException e) {
+        throw new MappingException(String.format("Cannot create property descriptor for record component '%s' in %s.",
+            component.getName(), recordType.getName()));
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/com/remondis/remap/PropertyPathCollectionTransformation.java
+++ b/src/main/java/com/remondis/remap/PropertyPathCollectionTransformation.java
@@ -121,6 +121,12 @@ public class PropertyPathCollectionTransformation<RS, X, RD> extends Transformat
   }
 
   @Override
+  MappedResult computeValue(Object sourceObject) {
+    Object sourceValue = readOrFail(sourceProperty, sourceObject);
+    return performValueTransformation(sourceValue, null);
+  }
+
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();

--- a/src/main/java/com/remondis/remap/PropertyPathTransformation.java
+++ b/src/main/java/com/remondis/remap/PropertyPathTransformation.java
@@ -98,6 +98,12 @@ public class PropertyPathTransformation<RS, X, RD> extends Transformation {
   }
 
   @Override
+  MappedResult computeValue(Object sourceObject) {
+    Object sourceValue = readOrFail(sourceProperty, sourceObject);
+    return performValueTransformation(sourceValue, null);
+  }
+
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();

--- a/src/main/java/com/remondis/remap/ReplaceCollectionTransformation.java
+++ b/src/main/java/com/remondis/remap/ReplaceCollectionTransformation.java
@@ -85,6 +85,12 @@ class ReplaceCollectionTransformation<RS, RD> extends SkipWhenNullTransformation
   }
 
   @Override
+  MappedResult computeValue(Object sourceObject) {
+    Object sourceValue = readOrFail(sourceProperty, sourceObject);
+    return performValueTransformation(sourceValue, null);
+  }
+
+  @Override
   Function<RS, RD> getTransformation() {
     return transformation;
   }

--- a/src/main/java/com/remondis/remap/ReplaceTransformation.java
+++ b/src/main/java/com/remondis/remap/ReplaceTransformation.java
@@ -58,6 +58,12 @@ class ReplaceTransformation<RS, RD> extends SkipWhenNullTransformation<RS, RD> {
   }
 
   @Override
+  MappedResult computeValue(Object sourceObject) {
+    Object sourceValue = readOrFail(sourceProperty, sourceObject);
+    return performValueTransformation(sourceValue, null);
+  }
+
+  @Override
   public String toString(boolean detailed) {
     if (skipWhenNull) {
       return String.format(REPLACE_SKIPPED_MSG, asString(sourceProperty, detailed),

--- a/src/main/java/com/remondis/remap/Transformation.java
+++ b/src/main/java/com/remondis/remap/Transformation.java
@@ -143,6 +143,26 @@ abstract class Transformation {
   }
 
   /**
+   * Computes the value that this transformation would write to the destination, without actually writing it.
+   * Used for record destination construction where values must be collected before invoking the canonical constructor.
+   *
+   * @param sourceObject The source object to read from.
+   * @return The computed result, or {@link MappedResult#skip()} if no value should be written.
+   */
+  MappedResult computeValue(Object sourceObject) {
+    if (sourceProperty != null) {
+      Object sourceValue = readOrFail(sourceProperty, sourceObject);
+      if (sourceValue == null) {
+        return mapping.isWriteNull() ? MappedResult.value(null) : MappedResult.skip();
+      }
+      return performValueTransformation(sourceValue, null);
+    } else {
+      // Transformations without source property (e.g., SetTransformation) use the whole source object
+      return performValueTransformation(sourceObject, null);
+    }
+  }
+
+  /**
    * Performs a single transformation step while mapping.
    *
    * @param sourceProperty The source property

--- a/src/main/java/com/remondis/remap/TypedSelector.java
+++ b/src/main/java/com/remondis/remap/TypedSelector.java
@@ -12,7 +12,7 @@ package com.remondis.remap;
  * @author schuettec
  */
 @FunctionalInterface
-public interface TypedSelector<R, T> {
+public interface TypedSelector<R, T> extends java.io.Serializable {
 
   /**
    * This method is used to perform a get-method invocation of the specified destination object and returning its value.

--- a/src/main/java/com/remondis/remap/Types.java
+++ b/src/main/java/com/remondis/remap/Types.java
@@ -19,6 +19,9 @@ public final class Types<S> {
   }
 
   private void denyNoDefaultConstructor(Class<?> type) {
+    if (type.isRecord()) {
+      return;
+    }
     try {
       Constructor<?> constructor = type.getConstructor();
       if (constructor == null) {

--- a/src/test/java/com/remondis/remap/records/AddressPojo.java
+++ b/src/test/java/com/remondis/remap/records/AddressPojo.java
@@ -1,0 +1,35 @@
+package com.remondis.remap.records;
+
+/**
+ * A nested POJO for testing hierarchical mapping with records.
+ */
+public class AddressPojo {
+
+  private String street;
+  private String city;
+
+  public AddressPojo() {
+  }
+
+  public AddressPojo(String street, String city) {
+    this.street = street;
+    this.city = city;
+  }
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/records/AddressRecord.java
+++ b/src/test/java/com/remondis/remap/records/AddressRecord.java
@@ -1,0 +1,7 @@
+package com.remondis.remap.records;
+
+/**
+ * A nested record for testing hierarchical mapping with records.
+ */
+public record AddressRecord(String street, String city) {
+}

--- a/src/test/java/com/remondis/remap/records/PersonPojo.java
+++ b/src/test/java/com/remondis/remap/records/PersonPojo.java
@@ -1,0 +1,55 @@
+package com.remondis.remap.records;
+
+/**
+ * Source POJO for POJO-to-Record mapping tests.
+ */
+public class PersonPojo {
+
+  private String name;
+  private int age;
+  private String email;
+  private boolean active;
+
+  public PersonPojo() {
+  }
+
+  public PersonPojo(String name, int age, String email, boolean active) {
+    this.name = name;
+    this.age = age;
+    this.email = email;
+    this.active = active;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/records/PersonRecord.java
+++ b/src/test/java/com/remondis/remap/records/PersonRecord.java
@@ -1,0 +1,7 @@
+package com.remondis.remap.records;
+
+/**
+ * Record with same field names as {@link PersonPojo} for implicit mapping tests.
+ */
+public record PersonRecord(String name, int age, String email, boolean active) {
+}

--- a/src/test/java/com/remondis/remap/records/PersonResourcePojo.java
+++ b/src/test/java/com/remondis/remap/records/PersonResourcePojo.java
@@ -1,0 +1,48 @@
+package com.remondis.remap.records;
+
+/**
+ * POJO with different field names for Record-to-POJO reassign tests.
+ */
+public class PersonResourcePojo {
+
+  private String fullName;
+  private int yearsOld;
+  private String emailAddress;
+  private boolean isActive;
+
+  public PersonResourcePojo() {
+  }
+
+  public String getFullName() {
+    return fullName;
+  }
+
+  public void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
+
+  public int getYearsOld() {
+    return yearsOld;
+  }
+
+  public void setYearsOld(int yearsOld) {
+    this.yearsOld = yearsOld;
+  }
+
+  public String getEmailAddress() {
+    return emailAddress;
+  }
+
+  public void setEmailAddress(String emailAddress) {
+    this.emailAddress = emailAddress;
+  }
+
+  public boolean isIsActive() {
+    return isActive;
+  }
+
+  public void setIsActive(boolean isActive) {
+    this.isActive = isActive;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/records/PersonResourceRecord.java
+++ b/src/test/java/com/remondis/remap/records/PersonResourceRecord.java
@@ -1,0 +1,7 @@
+package com.remondis.remap.records;
+
+/**
+ * Record with different field names for reassign tests.
+ */
+public record PersonResourceRecord(String fullName, int yearsOld, String emailAddress, boolean isActive) {
+}

--- a/src/test/java/com/remondis/remap/records/PersonWithAddressPojo.java
+++ b/src/test/java/com/remondis/remap/records/PersonWithAddressPojo.java
@@ -1,0 +1,35 @@
+package com.remondis.remap.records;
+
+/**
+ * POJO with a nested complex type for hierarchical mapping tests.
+ */
+public class PersonWithAddressPojo {
+
+  private String name;
+  private AddressPojo address;
+
+  public PersonWithAddressPojo() {
+  }
+
+  public PersonWithAddressPojo(String name, AddressPojo address) {
+    this.name = name;
+    this.address = address;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public AddressPojo getAddress() {
+    return address;
+  }
+
+  public void setAddress(AddressPojo address) {
+    this.address = address;
+  }
+
+}

--- a/src/test/java/com/remondis/remap/records/PersonWithAddressRecord.java
+++ b/src/test/java/com/remondis/remap/records/PersonWithAddressRecord.java
@@ -1,0 +1,7 @@
+package com.remondis.remap.records;
+
+/**
+ * Record with a nested complex type for hierarchical mapping tests.
+ */
+public record PersonWithAddressRecord(String name, AddressRecord address) {
+}

--- a/src/test/java/com/remondis/remap/records/PersonWithExtraRecord.java
+++ b/src/test/java/com/remondis/remap/records/PersonWithExtraRecord.java
@@ -1,0 +1,7 @@
+package com.remondis.remap.records;
+
+/**
+ * Record with an extra field not in the source, for omitInDestination tests.
+ */
+public record PersonWithExtraRecord(String name, int age, String extra) {
+}

--- a/src/test/java/com/remondis/remap/records/RecordMappingTest.java
+++ b/src/test/java/com/remondis/remap/records/RecordMappingTest.java
@@ -375,8 +375,10 @@ public class RecordMappingTest {
 
   // ==================== Error Cases ====================
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void shouldThrowOnMapIntoRecord() {
+  // ==================== MapInto (map with existing record) ====================
+
+  @Test
+  public void shouldMapIntoRecord_overwriteAllFields() {
     Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
         .to(PersonRecord.class)
         .mapper();
@@ -384,7 +386,137 @@ public class RecordMappingTest {
     PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
     PersonRecord existing = new PersonRecord("Old", 0, "old@example.com", false);
 
-    mapper.map(source, existing);
+    PersonRecord result = mapper.map(source, existing);
+
+    assertEquals("Alice", result.name());
+    assertEquals(30, result.age());
+    assertEquals("alice@example.com", result.email());
+    assertTrue(result.active());
+  }
+
+  @Test
+  public void shouldMapIntoRecord_preserveOmittedFields() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .omitInSource(PersonPojo::getAge)
+        .omitInDestination(PersonRecord::age)
+        .omitInSource(PersonPojo::isActive)
+        .omitInDestination(PersonRecord::active)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 99, "alice@example.com", true);
+    PersonRecord existing = new PersonRecord("Old", 42, "old@example.com", true);
+
+    PersonRecord result = mapper.map(source, existing);
+
+    // Mapped fields are overwritten
+    assertEquals("Alice", result.name());
+    assertEquals("alice@example.com", result.email());
+    // Omitted fields are preserved from existing record
+    assertEquals(42, result.age());
+    assertTrue(result.active());
+  }
+
+  @Test
+  public void shouldMapIntoRecord_returnsNewInstance() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord existing = new PersonRecord("Old", 0, "old@example.com", false);
+
+    PersonRecord result = mapper.map(source, existing);
+
+    // Records are immutable — result must be a new instance
+    assertFalse(result == existing);
+  }
+
+  @Test
+  public void shouldMapIntoRecord_recordToRecord_preserveOmitted() {
+    Mapper<PersonRecord, PersonResourceRecord> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourceRecord.class)
+        .reassign(PersonRecord::name)
+        .to(PersonResourceRecord::fullName)
+        .reassign(PersonRecord::email)
+        .to(PersonResourceRecord::emailAddress)
+        .omitInSource(PersonRecord::age)
+        .omitInSource(PersonRecord::active)
+        .omitInDestination(PersonResourceRecord::yearsOld)
+        .omitInDestination(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("New", 10, "new@example.com", false);
+    PersonResourceRecord existing = new PersonResourceRecord("Old", 50, "old@example.com", true);
+
+    PersonResourceRecord result = mapper.map(source, existing);
+
+    // Mapped fields overwritten
+    assertEquals("New", result.fullName());
+    assertEquals("new@example.com", result.emailAddress());
+    // Omitted fields preserved from existing
+    assertEquals(50, result.yearsOld());
+    assertTrue(result.isActive());
+  }
+
+  @Test
+  public void shouldMapIntoRecord_withNullDestination_createsNew() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord result = mapper.map(source, null);
+
+    assertEquals("Alice", result.name());
+    assertEquals(30, result.age());
+  }
+
+  @Test
+  public void shouldMapIntoRecord_withNestedMapper() {
+    Mapper<AddressPojo, AddressRecord> addressMapper = Mapping.from(AddressPojo.class)
+        .to(AddressRecord.class)
+        .mapper();
+
+    Mapper<PersonWithAddressPojo, PersonWithAddressRecord> mapper = Mapping.from(PersonWithAddressPojo.class)
+        .to(PersonWithAddressRecord.class)
+        .useMapper(addressMapper)
+        .mapper();
+
+    PersonWithAddressPojo source = new PersonWithAddressPojo("New", new AddressPojo("New St", "New City"));
+    PersonWithAddressRecord existing = new PersonWithAddressRecord("Old", new AddressRecord("Old St", "Old City"));
+
+    PersonWithAddressRecord result = mapper.map(source, existing);
+
+    assertEquals("New", result.name());
+    assertNotNull(result.address());
+    assertEquals("New St", result.address()
+        .street());
+    assertEquals("New City", result.address()
+        .city());
+  }
+
+  @Test
+  public void shouldMapIntoRecord_withReplace() {
+    Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonResourceRecord.class)
+        .replace(PersonPojo::getName, PersonResourceRecord::fullName)
+        .with(name -> name.toUpperCase())
+        .reassign(PersonPojo::getAge)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonPojo::getEmail)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonPojo::isActive)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Bob", 25, "bob@example.com", false);
+    PersonResourceRecord existing = new PersonResourceRecord("Old", 99, "old@example.com", true);
+
+    PersonResourceRecord result = mapper.map(source, existing);
+
+    assertEquals("BOB", result.fullName());
+    assertEquals(25, result.yearsOld());
   }
 
   @Test(expected = MappingException.class)

--- a/src/test/java/com/remondis/remap/records/RecordMappingTest.java
+++ b/src/test/java/com/remondis/remap/records/RecordMappingTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -574,6 +575,67 @@ public class RecordMappingTest {
     assertEquals("Alice", result.name());
     assertEquals(0, result.age());
     assertFalse(result.active());
+  }
+
+  // ==================== Set Operation ====================
+
+  @Test
+  public void shouldMapPojoToRecord_withSet() {
+    Mapper<PersonPojo, PersonWithExtraRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonWithExtraRecord.class)
+        .omitInSource(PersonPojo::getEmail)
+        .omitInSource(PersonPojo::isActive)
+        .set(PersonWithExtraRecord::extra)
+        .with(source -> source.getName() + "-extra")
+        .mapper();
+
+    PersonWithExtraRecord result = mapper.map(new PersonPojo("John", 30, "john@example.com", true));
+
+    assertEquals("John", result.name());
+    assertEquals(30, result.age());
+    assertEquals("John-extra", result.extra());
+  }
+
+  // ==================== Restructure Operation ====================
+
+  @Test
+  public void shouldMapPojoToRecord_withRestructure() {
+    Mapper<PersonPojo, PersonWithAddressRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonWithAddressRecord.class)
+        .omitOtherSourceProperties()
+        .restructure(PersonWithAddressRecord::address)
+        .applying(config -> config.replace(PersonPojo::getEmail, AddressRecord::street)
+            .withSkipWhenNull(email -> email)
+            .replace(PersonPojo::getName, AddressRecord::city)
+            .withSkipWhenNull(name -> name))
+        .mapper();
+
+    PersonWithAddressRecord result = mapper.map(new PersonPojo("Dortmund", 30, "Main Street 1", false));
+
+    assertEquals("Dortmund", result.name());
+    assertNotNull(result.address());
+    assertEquals("Main Street 1", result.address()
+        .street());
+    assertEquals("Dortmund", result.address()
+        .city());
+  }
+
+  // ==================== Selector Validation ====================
+
+  @Test
+  public void shouldThrowOnInlineLambdaForRecordSelector() {
+    try {
+      Mapping.from(PersonPojo.class)
+          .to(PersonRecord.class)
+          .omitInDestination(record -> record.email())
+          .mapper();
+      fail("MappingException expected for inline lambda on record type");
+    } catch (MappingException e) {
+      assertTrue("Expected a hint to use method references, but was: " + e.getMessage(), e.getMessage()
+          .contains("method references"));
+      assertTrue("Expected the inline lambda to be reported, but was: " + e.getMessage(), e.getMessage()
+          .contains("inline lambda"));
+    }
   }
 
 }

--- a/src/test/java/com/remondis/remap/records/RecordMappingTest.java
+++ b/src/test/java/com/remondis/remap/records/RecordMappingTest.java
@@ -1,0 +1,447 @@
+package com.remondis.remap.records;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.remondis.remap.AssertMapping;
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.MappingException;
+
+public class RecordMappingTest {
+
+  // ==================== POJO -> Record ====================
+
+  @Test
+  public void shouldMapPojoToRecord_implicit() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord result = mapper.map(source);
+
+    assertEquals("Alice", result.name());
+    assertEquals(30, result.age());
+    assertEquals("alice@example.com", result.email());
+    assertTrue(result.active());
+  }
+
+  @Test
+  public void shouldMapPojoToRecord_withReassign() {
+    Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonResourceRecord.class)
+        .reassign(PersonPojo::getName)
+        .to(PersonResourceRecord::fullName)
+        .reassign(PersonPojo::getAge)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonPojo::getEmail)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonPojo::isActive)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Bob", 25, "bob@example.com", false);
+    PersonResourceRecord result = mapper.map(source);
+
+    assertEquals("Bob", result.fullName());
+    assertEquals(25, result.yearsOld());
+    assertEquals("bob@example.com", result.emailAddress());
+    assertFalse(result.isActive());
+  }
+
+  @Test
+  public void shouldMapPojoToRecord_withReplace() {
+    Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonResourceRecord.class)
+        .replace(PersonPojo::getName, PersonResourceRecord::fullName)
+        .with(name -> name.toUpperCase())
+        .reassign(PersonPojo::getAge)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonPojo::getEmail)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonPojo::isActive)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Charlie", 35, "charlie@example.com", true);
+    PersonResourceRecord result = mapper.map(source);
+
+    assertEquals("CHARLIE", result.fullName());
+  }
+
+  @Test
+  public void shouldMapPojoToRecord_withOmitInSource() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .omitInSource(PersonPojo::getEmail)
+        .omitInDestination(PersonRecord::email)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord result = mapper.map(source);
+
+    assertEquals("Alice", result.name());
+    assertEquals(30, result.age());
+    assertNull(result.email());
+    assertTrue(result.active());
+  }
+
+  @Test
+  public void shouldMapPojoToRecord_withOmitInDestination() {
+    Mapper<PersonPojo, PersonWithExtraRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonWithExtraRecord.class)
+        .omitInSource(PersonPojo::getEmail)
+        .omitInSource(PersonPojo::isActive)
+        .omitInDestination(PersonWithExtraRecord::extra)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonWithExtraRecord result = mapper.map(source);
+
+    assertEquals("Alice", result.name());
+    assertEquals(30, result.age());
+    assertNull(result.extra());
+  }
+
+  // ==================== Record -> POJO ====================
+
+  @Test
+  public void shouldMapRecordToPojo_implicit() {
+    Mapper<PersonRecord, PersonPojo> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonPojo.class)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Diana", 28, "diana@example.com", false);
+    PersonPojo result = mapper.map(source);
+
+    assertEquals("Diana", result.getName());
+    assertEquals(28, result.getAge());
+    assertEquals("diana@example.com", result.getEmail());
+    assertFalse(result.isActive());
+  }
+
+  @Test
+  public void shouldMapRecordToPojo_withReassign() {
+    Mapper<PersonRecord, PersonResourcePojo> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourcePojo.class)
+        .reassign(PersonRecord::name)
+        .to(PersonResourcePojo::getFullName)
+        .reassign(PersonRecord::age)
+        .to(PersonResourcePojo::getYearsOld)
+        .reassign(PersonRecord::email)
+        .to(PersonResourcePojo::getEmailAddress)
+        .reassign(PersonRecord::active)
+        .to(PersonResourcePojo::isIsActive)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Eve", 40, "eve@example.com", true);
+    PersonResourcePojo result = mapper.map(source);
+
+    assertEquals("Eve", result.getFullName());
+    assertEquals(40, result.getYearsOld());
+    assertEquals("eve@example.com", result.getEmailAddress());
+    assertTrue(result.isIsActive());
+  }
+
+  @Test
+  public void shouldMapRecordToPojo_withReplace() {
+    Mapper<PersonRecord, PersonResourcePojo> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourcePojo.class)
+        .replace(PersonRecord::name, PersonResourcePojo::getFullName)
+        .with(name -> "Dr. " + name)
+        .reassign(PersonRecord::age)
+        .to(PersonResourcePojo::getYearsOld)
+        .reassign(PersonRecord::email)
+        .to(PersonResourcePojo::getEmailAddress)
+        .reassign(PersonRecord::active)
+        .to(PersonResourcePojo::isIsActive)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Frank", 50, "frank@example.com", false);
+    PersonResourcePojo result = mapper.map(source);
+
+    assertEquals("Dr. Frank", result.getFullName());
+  }
+
+  // ==================== Record -> Record ====================
+
+  @Test
+  public void shouldMapRecordToRecord_implicit() {
+    Mapper<PersonRecord, PersonRecord> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Grace", 22, "grace@example.com", true);
+    PersonRecord result = mapper.map(source);
+
+    assertEquals("Grace", result.name());
+    assertEquals(22, result.age());
+    assertEquals("grace@example.com", result.email());
+    assertTrue(result.active());
+  }
+
+  @Test
+  public void shouldMapRecordToRecord_withReassign() {
+    Mapper<PersonRecord, PersonResourceRecord> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourceRecord.class)
+        .reassign(PersonRecord::name)
+        .to(PersonResourceRecord::fullName)
+        .reassign(PersonRecord::age)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonRecord::email)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonRecord::active)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Hank", 60, "hank@example.com", false);
+    PersonResourceRecord result = mapper.map(source);
+
+    assertEquals("Hank", result.fullName());
+    assertEquals(60, result.yearsOld());
+    assertEquals("hank@example.com", result.emailAddress());
+    assertFalse(result.isActive());
+  }
+
+  @Test
+  public void shouldMapRecordToRecord_withReplace() {
+    Mapper<PersonRecord, PersonResourceRecord> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourceRecord.class)
+        .replace(PersonRecord::name, PersonResourceRecord::fullName)
+        .with(n -> n + " (verified)")
+        .replace(PersonRecord::age, PersonResourceRecord::yearsOld)
+        .with(a -> a + 1)
+        .reassign(PersonRecord::email)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonRecord::active)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    PersonRecord source = new PersonRecord("Ivy", 29, "ivy@example.com", true);
+    PersonResourceRecord result = mapper.map(source);
+
+    assertEquals("Ivy (verified)", result.fullName());
+    assertEquals(30, result.yearsOld());
+  }
+
+  // ==================== Nested / Hierarchical Mapping ====================
+
+  @Test
+  public void shouldMapPojoToRecord_withNestedMapper() {
+    Mapper<AddressPojo, AddressRecord> addressMapper = Mapping.from(AddressPojo.class)
+        .to(AddressRecord.class)
+        .mapper();
+
+    Mapper<PersonWithAddressPojo, PersonWithAddressRecord> mapper = Mapping.from(PersonWithAddressPojo.class)
+        .to(PersonWithAddressRecord.class)
+        .useMapper(addressMapper)
+        .mapper();
+
+    PersonWithAddressPojo source = new PersonWithAddressPojo("John", new AddressPojo("Main St", "Springfield"));
+    PersonWithAddressRecord result = mapper.map(source);
+
+    assertEquals("John", result.name());
+    assertNotNull(result.address());
+    assertEquals("Main St", result.address()
+        .street());
+    assertEquals("Springfield", result.address()
+        .city());
+  }
+
+  @Test
+  public void shouldMapRecordToPojo_withNestedMapper() {
+    Mapper<AddressRecord, AddressPojo> addressMapper = Mapping.from(AddressRecord.class)
+        .to(AddressPojo.class)
+        .mapper();
+
+    Mapper<PersonWithAddressRecord, PersonWithAddressPojo> mapper = Mapping.from(PersonWithAddressRecord.class)
+        .to(PersonWithAddressPojo.class)
+        .useMapper(addressMapper)
+        .mapper();
+
+    PersonWithAddressRecord source = new PersonWithAddressRecord("Jane", new AddressRecord("Oak Ave", "Shelbyville"));
+    PersonWithAddressPojo result = mapper.map(source);
+
+    assertEquals("Jane", result.getName());
+    assertNotNull(result.getAddress());
+    assertEquals("Oak Ave", result.getAddress()
+        .getStreet());
+    assertEquals("Shelbyville", result.getAddress()
+        .getCity());
+  }
+
+  @Test
+  public void shouldMapRecordToRecord_withNestedMapper() {
+    Mapper<AddressRecord, AddressRecord> addressMapper = Mapping.from(AddressRecord.class)
+        .to(AddressRecord.class)
+        .mapper();
+
+    Mapper<PersonWithAddressRecord, PersonWithAddressRecord> mapper = Mapping.from(PersonWithAddressRecord.class)
+        .to(PersonWithAddressRecord.class)
+        .useMapper(addressMapper)
+        .mapper();
+
+    PersonWithAddressRecord source = new PersonWithAddressRecord("Kate", new AddressRecord("Elm St", "Capital City"));
+    PersonWithAddressRecord result = mapper.map(source);
+
+    assertEquals("Kate", result.name());
+    assertEquals("Elm St", result.address()
+        .street());
+    assertEquals("Capital City", result.address()
+        .city());
+  }
+
+  // ==================== AssertMapping ====================
+
+  @Test
+  public void shouldAssertPojoToRecordMapping() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    AssertMapping.of(mapper)
+        .expectOthersToBeOmitted()
+        .ensure();
+  }
+
+  @Test
+  public void shouldAssertRecordToPojoMapping() {
+    Mapper<PersonRecord, PersonPojo> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonPojo.class)
+        .mapper();
+
+    AssertMapping.of(mapper)
+        .expectOthersToBeOmitted()
+        .ensure();
+  }
+
+  @Test
+  public void shouldAssertRecordToRecordMapping_withReassign() {
+    Mapper<PersonRecord, PersonResourceRecord> mapper = Mapping.from(PersonRecord.class)
+        .to(PersonResourceRecord.class)
+        .reassign(PersonRecord::name)
+        .to(PersonResourceRecord::fullName)
+        .reassign(PersonRecord::age)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonRecord::email)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonRecord::active)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    AssertMapping.of(mapper)
+        .expectReassign(PersonRecord::name)
+        .to(PersonResourceRecord::fullName)
+        .expectReassign(PersonRecord::age)
+        .to(PersonResourceRecord::yearsOld)
+        .expectReassign(PersonRecord::email)
+        .to(PersonResourceRecord::emailAddress)
+        .expectReassign(PersonRecord::active)
+        .to(PersonResourceRecord::isActive)
+        .ensure();
+  }
+
+  @Test
+  public void shouldAssertRecordMapping_withReplace() {
+    Mapper<PersonPojo, PersonResourceRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonResourceRecord.class)
+        .replace(PersonPojo::getName, PersonResourceRecord::fullName)
+        .with(name -> name == null ? null : name.toUpperCase())
+        .reassign(PersonPojo::getAge)
+        .to(PersonResourceRecord::yearsOld)
+        .reassign(PersonPojo::getEmail)
+        .to(PersonResourceRecord::emailAddress)
+        .reassign(PersonPojo::isActive)
+        .to(PersonResourceRecord::isActive)
+        .mapper();
+
+    AssertMapping.of(mapper)
+        .expectReplace(PersonPojo::getName, PersonResourceRecord::fullName)
+        .andTest(name -> name == null ? null : name.toUpperCase())
+        .expectReassign(PersonPojo::getAge)
+        .to(PersonResourceRecord::yearsOld)
+        .expectReassign(PersonPojo::getEmail)
+        .to(PersonResourceRecord::emailAddress)
+        .expectReassign(PersonPojo::isActive)
+        .to(PersonResourceRecord::isActive)
+        .ensure();
+  }
+
+  // ==================== Error Cases ====================
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldThrowOnMapIntoRecord() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord existing = new PersonRecord("Old", 0, "old@example.com", false);
+
+    mapper.map(source, existing);
+  }
+
+  @Test(expected = MappingException.class)
+  public void shouldThrowOnUnmappedRecordField() {
+    Mapping.from(PersonPojo.class)
+        .to(PersonWithExtraRecord.class)
+        .mapper();
+  }
+
+  @Test(expected = MappingException.class)
+  public void shouldDenyMappingNullToRecord() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    mapper.map((PersonPojo) null);
+  }
+
+  // ==================== Collection Mapping ====================
+
+  @Test
+  public void shouldMapCollectionOfPojosToRecords() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .mapper();
+
+    java.util.List<PersonPojo> sources = new java.util.ArrayList<>();
+    sources.add(new PersonPojo("A", 1, "a@x.com", true));
+    sources.add(new PersonPojo("B", 2, "b@x.com", false));
+
+    java.util.List<PersonRecord> results = mapper.map(sources);
+
+    assertEquals(2, results.size());
+    assertEquals("A", results.get(0)
+        .name());
+    assertEquals("B", results.get(1)
+        .name());
+  }
+
+  // ==================== Primitive Defaults ====================
+
+  @Test
+  public void shouldSetPrimitiveDefaultsForOmittedRecordFields() {
+    Mapper<PersonPojo, PersonRecord> mapper = Mapping.from(PersonPojo.class)
+        .to(PersonRecord.class)
+        .omitInSource(PersonPojo::getAge)
+        .omitInDestination(PersonRecord::age)
+        .omitInSource(PersonPojo::isActive)
+        .omitInDestination(PersonRecord::active)
+        .mapper();
+
+    PersonPojo source = new PersonPojo("Alice", 30, "alice@example.com", true);
+    PersonRecord result = mapper.map(source);
+
+    assertEquals("Alice", result.name());
+    assertEquals(0, result.age());
+    assertFalse(result.active());
+  }
+
+}


### PR DESCRIPTION
Adds Java Record mapping support: records as source (accessor-based properties via `RecordComponent`), records as destination (values collected per transformation, canonical constructor invocation), selector support for records via `SerializedLambda` method references (ByteBuddy cannot proxy final record classes).

**Update 2026-07-07 - aligned with the open performance/fix PRs:** this branch now includes the changes of #173 and #176-#181 (merged in), because record support touches the same code paths. It should therefore be merged **last**; the diff will reduce to the record feature as the other PRs land. Adaptations made on top of the plain feature:

- The record early-return in the selector evaluation is ordered before the sensor access and combined with the defensive tracking reset of #181 (for records no invocation sensor exists).
- `Properties.getProperties` record handling merged with the interface-property filtering of #176.
- The canonical record constructor is now resolved once on the first mapping instead of per mapped object, following the cached-constructor pattern introduced in #178. Record value transformations automatically benefit from the pre-bound conversion strategies of #179.

Verified on the combined state: 225 tests green, including the full `RecordMappingTest` suite.

---
🤖 Co-updated with [Claude Code](https://claude.com/claude-code)