### PR TITLE
fix: use LinkedHashSet for deterministic mapping order

### DIFF
--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -111,7 +112,7 @@ public class MappingConfiguration<S, D> {
   MappingConfiguration(Class<S> source, Class<D> destination) {
     this.source = source;
     this.destination = destination;
-    this.mappings = new HashSet<>();
+    this.mappings = new LinkedHashSet<>();
     this.mappedSourceProperties = new HashSet<>();
     this.mappedDestinationProperties = new HashSet<>();
     this.mappers = new Hashtable<>();
@@ -802,7 +803,7 @@ public class MappingConfiguration<S, D> {
   }
 
   Set<Transformation> getMappings() {
-    return new HashSet<>(mappings);
+    return new LinkedHashSet<>(mappings);
   }
 
   @Override

--- a/src/test/java/com/remondis/remap/DeterministicMappingOrderTest.java
+++ b/src/test/java/com/remondis/remap/DeterministicMappingOrderTest.java
@@ -1,0 +1,137 @@
+package com.remondis.remap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that transformations are performed in configuration order. Before mappings were held in a
+ * {@link java.util.LinkedHashSet}, the iteration order depended on hash codes, so the mapping order and the order of
+ * transformations in error messages were not deterministic.
+ */
+public class DeterministicMappingOrderTest {
+
+  @Test
+  public void shouldKeepConfigurationOrderOfTransformations() {
+    Mapper<Source, Destination> mapper = Mapping.from(Source.class)
+        .to(Destination.class)
+        .reassign(Source::getThree)
+        .to(Destination::getThird)
+        .reassign(Source::getOne)
+        .to(Destination::getFirst)
+        .reassign(Source::getFive)
+        .to(Destination::getFifth)
+        .reassign(Source::getTwo)
+        .to(Destination::getSecond)
+        .reassign(Source::getFour)
+        .to(Destination::getFourth)
+        .mapper();
+
+    List<String> destinationPropertyOrder = mapper.getMapping()
+        .getMappings()
+        .stream()
+        .map(Transformation::getDestinationPropertyName)
+        .collect(Collectors.toList());
+
+    assertThat(destinationPropertyOrder).containsExactly("third", "first", "fifth", "second", "fourth");
+  }
+
+  public static class Source {
+    private String one;
+    private String two;
+    private String three;
+    private String four;
+    private String five;
+
+    public String getOne() {
+      return one;
+    }
+
+    public void setOne(String one) {
+      this.one = one;
+    }
+
+    public String getTwo() {
+      return two;
+    }
+
+    public void setTwo(String two) {
+      this.two = two;
+    }
+
+    public String getThree() {
+      return three;
+    }
+
+    public void setThree(String three) {
+      this.three = three;
+    }
+
+    public String getFour() {
+      return four;
+    }
+
+    public void setFour(String four) {
+      this.four = four;
+    }
+
+    public String getFive() {
+      return five;
+    }
+
+    public void setFive(String five) {
+      this.five = five;
+    }
+  }
+
+  public static class Destination {
+    private String first;
+    private String second;
+    private String third;
+    private String fourth;
+    private String fifth;
+
+    public String getFirst() {
+      return first;
+    }
+
+    public void setFirst(String first) {
+      this.first = first;
+    }
+
+    public String getSecond() {
+      return second;
+    }
+
+    public void setSecond(String second) {
+      this.second = second;
+    }
+
+    public String getThird() {
+      return third;
+    }
+
+    public void setThird(String third) {
+      this.third = third;
+    }
+
+    public String getFourth() {
+      return fourth;
+    }
+
+    public void setFourth(String fourth) {
+      this.fourth = fourth;
+    }
+
+    public String getFifth() {
+      return fifth;
+    }
+
+    public void setFifth(String fifth) {
+      this.fifth = fifth;
+    }
+  }
+}


### PR DESCRIPTION
Uses `LinkedHashSet` for the mapping operations so that transformations are performed in configuration order. Before, the iteration order depended on hash codes, so the mapping order and the order of transformations in error messages were not deterministic across JVM runs.

Update 2026-07-07: added a regression test (`DeterministicMappingOrderTest`) asserting that transformations iterate in configuration order - this also guards the behavior against future changes to the mappings collection (e.g. for performance reasons).

Compatibility: verified against the open performance/fix PRs #176-#181 by test-merging everything together (202 tests green on the combined state). Recommended to merge this PR **early** - the only overlap is a trivial import conflict with #178, which will be resolved on that side.

---
🤖 Co-updated with [Claude Code](https://claude.com/claude-code)