### PR TITLE
Fix #175: Do not report read-only interface properties as missing mappings

### DIFF
--- a/src/main/java/com/remondis/remap/Properties.java
+++ b/src/main/java/com/remondis/remap/Properties.java
@@ -120,7 +120,7 @@ class Properties {
   static Set<PropertyDescriptor> getProperties(Class<?> inspectType, Target targetType, boolean fluentSetters) {
     try {
       Set<PropertyDescriptor> result = extractBaseProperties(inspectType, targetType, fluentSetters);
-      mergeInterfaceProperties(inspectType, result);
+      mergeInterfaceProperties(inspectType, targetType, result);
       return result;
     } catch (IntrospectionException e) {
       throw new MappingException(String.format("Cannot introspect the type %s.", inspectType.getName()));
@@ -149,7 +149,8 @@ class Properties {
   /**
    * Merges properties from implemented interfaces into the existing property set.
    */
-  private static void mergeInterfaceProperties(Class<?> inspectType, Set<PropertyDescriptor> result) {
+  private static void mergeInterfaceProperties(Class<?> inspectType, Target targetType,
+      Set<PropertyDescriptor> result) {
     for (Class<?> iface : inspectType.getInterfaces()) {
       Map<String, GetterSetterHolder> accessorsByProperty = new HashMap<>();
 
@@ -179,6 +180,14 @@ class Properties {
         PropertyDescriptor existing = findPropertyDescriptor(result, name);
 
         if (existing == null) {
+          // Interface properties are subject to the same access requirements as the base properties: a getter is
+          // always required and mapping targets additionally require a setter. Read-only properties declared by an
+          // interface are no mapping targets.
+          boolean isMappingCandidate = holder.getGetter() != null
+              && (Target.SOURCE.equals(targetType) || holder.getSetter() != null);
+          if (!isMappingCandidate) {
+            continue;
+          }
           try {
             PropertyDescriptor pd = new PropertyDescriptor(name, holder.getGetter(), holder.getSetter());
             result.add(pd);

--- a/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/A.java
+++ b/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/A.java
@@ -1,0 +1,18 @@
+package com.remondis.remap.regression.readOnlyInterfacePropertyBug;
+
+public class A implements B {
+  private Long id;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  @Override
+  public String getName() {
+    return "Test";
+  }
+}

--- a/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/B.java
+++ b/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/B.java
@@ -1,0 +1,5 @@
+package com.remondis.remap.regression.readOnlyInterfacePropertyBug;
+
+public interface B {
+  String getName();
+}

--- a/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/C.java
+++ b/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/C.java
@@ -1,0 +1,13 @@
+package com.remondis.remap.regression.readOnlyInterfacePropertyBug;
+
+public class C {
+  private Long id;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+}

--- a/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/MapperTest.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.regression.readOnlyInterfacePropertyBug;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+/**
+ * Reproduces <a href="https://github.com/remondis-it/remap/issues/175">issue #175</a>: If the mapping target
+ * implements an interface that declares a getter without a corresponding setter, the mapper reported this
+ * read-only property as a missing mapping although read-only properties are no mapping targets.
+ */
+public class MapperTest {
+
+  @Test
+  public void shouldCreateMapperIfTargetImplementsInterfaceWithReadOnlyProperty() {
+    Mapper<C, A> mapper = Mapping.from(C.class)
+        .to(A.class)
+        .mapper();
+
+    C source = new C();
+    source.setId(42L);
+
+    A target = mapper.map(source);
+
+    assertThat(target.getId()).isEqualTo(42L);
+    assertThat(target.getName()).isEqualTo("Test");
+  }
+}


### PR DESCRIPTION
Fixes #175.

When the mapping target implements an interface that declares a getter without a corresponding setter, `mergeInterfaceProperties` re-added the read-only property to the target property set although `extractBaseProperties` had correctly filtered it out. Mapper creation then failed with a `MappingException` reporting the property as unmapped (regression since 4.3.7).

Interface properties are now subject to the same access requirements as the base properties: a getter is always required, and mapping targets additionally require a setter.

Includes a regression test under `regression/readOnlyInterfacePropertyBug` reproducing the exact scenario from #175 (fails without the fix).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)