### PR TITLE
Add JMH benchmarks for mapping hot paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <jmh.version>1.37</jmh.version>
     </properties>
     <distributionManagement>
         <repository>
@@ -177,6 +178,9 @@
                     <optimize>true</optimize>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <parameters>true</parameters>
+                    <!-- Required for the JMH annotation processor (test scope) on newer JDKs where implicit
+                        annotation processing is disabled by default. -->
+                    <proc>full</proc>
                 </configuration>
             </plugin>
 
@@ -283,6 +287,18 @@
                 <version>3.27.7</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -336,6 +352,14 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/remondis/remap/benchmark/Address.java
+++ b/src/test/java/com/remondis/remap/benchmark/Address.java
@@ -1,0 +1,40 @@
+package com.remondis.remap.benchmark;
+
+public class Address {
+  private String street;
+  private String city;
+  private String zipCode;
+  private int number;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+
+  public void setNumber(int number) {
+    this.number = number;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/AddressDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/AddressDto.java
@@ -1,0 +1,40 @@
+package com.remondis.remap.benchmark;
+
+public class AddressDto {
+  private String street;
+  private String city;
+  private String zipCode;
+  private int number;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+
+  public void setNumber(int number) {
+    this.number = number;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
@@ -1,0 +1,37 @@
+package com.remondis.remap.benchmark;
+
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Runs the ReMap JMH benchmarks. Results are printed to the console and written to
+ * <code>target/jmh-result.json</code>.
+ *
+ * <p>
+ * The benchmark JVMs forked by JMH require the test classpath on <code>java.class.path</code>, so the runner must be
+ * started with a plain <code>java</code> command instead of <code>exec:java</code>:
+ *
+ * <pre>
+ * mvn test-compile dependency:build-classpath -Dmdep.outputFile=target/classpath.txt -Dmdep.includeScope=test
+ * java -cp "target/classes:target/test-classes:$(cat target/classpath.txt)" \
+ *     com.remondis.remap.benchmark.BenchmarkRunner
+ * </pre>
+ *
+ * (On Windows use <code>;</code> as path separator.) An optional first argument is used as benchmark include regex,
+ * e.g. <code>mapCollections</code>.
+ * </p>
+ */
+public class BenchmarkRunner {
+
+  public static void main(String[] args) throws RunnerException {
+    Options options = new OptionsBuilder().include(args.length > 0 ? args[0] : MappingBenchmark.class.getSimpleName())
+        .jvmArgsAppend("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+        .resultFormat(ResultFormatType.JSON)
+        .result("target/jmh-result.json")
+        .build();
+    new Runner(options).run();
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/Container.java
+++ b/src/test/java/com/remondis/remap/benchmark/Container.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+
+public class Container {
+  private List<String> tags;
+  private List<Address> addresses;
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<Address> getAddresses() {
+    return addresses;
+  }
+
+  public void setAddresses(List<Address> addresses) {
+    this.addresses = addresses;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/ContainerDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/ContainerDto.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+
+public class ContainerDto {
+  private List<String> tags;
+  private List<AddressDto> addresses;
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<AddressDto> getAddresses() {
+    return addresses;
+  }
+
+  public void setAddresses(List<AddressDto> addresses) {
+    this.addresses = addresses;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/FlatDestination.java
+++ b/src/test/java/com/remondis/remap/benchmark/FlatDestination.java
@@ -1,0 +1,94 @@
+package com.remondis.remap.benchmark;
+
+public class FlatDestination {
+  private long id;
+  private String firstName;
+  private String lastName;
+  private String street;
+  private String city;
+  private String zipCode;
+  private int age;
+  private boolean active;
+  private double score;
+  private Integer loginCount;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  public Integer getLoginCount() {
+    return loginCount;
+  }
+
+  public void setLoginCount(Integer loginCount) {
+    this.loginCount = loginCount;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/FlatSource.java
+++ b/src/test/java/com/remondis/remap/benchmark/FlatSource.java
@@ -1,0 +1,94 @@
+package com.remondis.remap.benchmark;
+
+public class FlatSource {
+  private long id;
+  private String firstName;
+  private String lastName;
+  private String street;
+  private String city;
+  private String zipCode;
+  private int age;
+  private boolean active;
+  private double score;
+  private Integer loginCount;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  public Integer getLoginCount() {
+    return loginCount;
+  }
+
+  public void setLoginCount(Integer loginCount) {
+    this.loginCount = loginCount;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/MappingBenchmark.java
+++ b/src/test/java/com/remondis/remap/benchmark/MappingBenchmark.java
@@ -1,0 +1,153 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+/**
+ * JMH benchmarks covering the mapping hot paths of ReMap:
+ * <ul>
+ * <li>{@link #mapFlatBean(MapperState)}: implicit mapping of a flat bean with 10 properties.</li>
+ * <li>{@link #mapNestedBean(MapperState)}: mapping with a nested object using a registered mapper.</li>
+ * <li>{@link #mapNestedBeanConcurrent(MapperState)}: same as above, but with 4 threads sharing one mapper
+ * instance.</li>
+ * <li>{@link #mapCollections(CollectionState)}: mapping of collections (reference elements and nested mapping per
+ * element).</li>
+ * <li>{@link #createMapper(MapperState)}: mapper creation (configuration time).</li>
+ * </ul>
+ * See {@link BenchmarkRunner} for how to run the benchmarks.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class MappingBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class MapperState {
+    Mapper<FlatSource, FlatDestination> flatMapper;
+    Mapper<Address, AddressDto> addressMapper;
+    Mapper<Person, PersonDto> personMapper;
+
+    FlatSource flatSource;
+    Person person;
+
+    @Setup
+    public void setup() {
+      flatMapper = Mapping.from(FlatSource.class)
+          .to(FlatDestination.class)
+          .mapper();
+      addressMapper = Mapping.from(Address.class)
+          .to(AddressDto.class)
+          .mapper();
+      personMapper = Mapping.from(Person.class)
+          .to(PersonDto.class)
+          .useMapper(addressMapper)
+          .mapper();
+
+      flatSource = new FlatSource();
+      flatSource.setId(4711L);
+      flatSource.setFirstName("John");
+      flatSource.setLastName("Doe");
+      flatSource.setStreet("Main Street");
+      flatSource.setCity("Springfield");
+      flatSource.setZipCode("12345");
+      flatSource.setAge(42);
+      flatSource.setActive(true);
+      flatSource.setScore(0.75d);
+      flatSource.setLoginCount(1337);
+
+      person = new Person();
+      person.setName("John Doe");
+      person.setAge(42);
+      person.setAddress(newAddress(1));
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class CollectionState {
+    @Param({
+        "10", "1000"
+    })
+    int collectionSize;
+
+    Mapper<Container, ContainerDto> containerMapper;
+    Container container;
+
+    @Setup
+    public void setup() {
+      Mapper<Address, AddressDto> addressMapper = Mapping.from(Address.class)
+          .to(AddressDto.class)
+          .mapper();
+      containerMapper = Mapping.from(Container.class)
+          .to(ContainerDto.class)
+          .useMapper(addressMapper)
+          .mapper();
+
+      container = new Container();
+      container.setTags(IntStream.range(0, collectionSize)
+          .mapToObj(i -> "tag-" + i)
+          .collect(Collectors.toList()));
+      List<Address> addresses = IntStream.range(0, collectionSize)
+          .mapToObj(MappingBenchmark::newAddress)
+          .collect(Collectors.toList());
+      container.setAddresses(addresses);
+    }
+  }
+
+  @Benchmark
+  public FlatDestination mapFlatBean(MapperState state) {
+    return state.flatMapper.map(state.flatSource);
+  }
+
+  @Benchmark
+  public PersonDto mapNestedBean(MapperState state) {
+    return state.personMapper.map(state.person);
+  }
+
+  @Benchmark
+  @Threads(4)
+  public PersonDto mapNestedBeanConcurrent(MapperState state) {
+    return state.personMapper.map(state.person);
+  }
+
+  @Benchmark
+  public ContainerDto mapCollections(CollectionState state) {
+    return state.containerMapper.map(state.container);
+  }
+
+  @Benchmark
+  public Mapper<Person, PersonDto> createMapper(MapperState state) {
+    return Mapping.from(Person.class)
+        .to(PersonDto.class)
+        .useMapper(state.addressMapper)
+        .mapper();
+  }
+
+  static Address newAddress(int i) {
+    Address address = new Address();
+    address.setStreet("Street " + i);
+    address.setCity("City " + i);
+    address.setZipCode(String.valueOf(10000 + i));
+    address.setNumber(i);
+    return address;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/Person.java
+++ b/src/test/java/com/remondis/remap/benchmark/Person.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.benchmark;
+
+public class Person {
+  private String name;
+  private int age;
+  private Address address;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/PersonDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/PersonDto.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.benchmark;
+
+public class PersonDto {
+  private String name;
+  private int age;
+  private AddressDto address;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public AddressDto getAddress() {
+    return address;
+  }
+
+  public void setAddress(AddressDto address) {
+    this.address = address;
+  }
+}


### PR DESCRIPTION
Adds JMH benchmarks covering the mapping hot paths as the measurement baseline for the follow-up performance PRs:

- `mapFlatBean`: implicit mapping of a flat bean with 10 properties
- `mapNestedBean`: mapping with a nested object via a registered mapper
- `mapNestedBeanConcurrent`: 4 threads sharing one mapper instance
- `mapCollections`: collection mapping with 10/1000 elements (reference elements and nested mapping per element)
- `createMapper`: mapper creation (configuration time)

Baseline on develop (JDK 21, avgt, us/op):

| Benchmark | Score |
|---|---|
| mapFlatBean | 0.470 +/- 0.014 |
| mapNestedBean | 0.360 +/- 0.003 |
| mapNestedBeanConcurrent (4T) | 0.904 +/- 0.081 |
| mapCollections (10) | 5.316 +/- 0.430 |
| mapCollections (1000) | 508.056 +/- 14.393 |
| createMapper | 1.919 +/- 0.015 |

The concurrent benchmark runs ~2.5x slower per operation than the single-threaded variant, pointing to lock contention on the shared mapper instance - addressed in the follow-up PRs.

JMH is added in test scope only. The forked benchmark JVMs need the test classpath on `java.class.path`, so the runner must be started with a plain `java` command instead of `exec:java` (see the `BenchmarkRunner` javadoc for the exact command).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)