### PR TITLE
Fix stale selector tracking state after failed selector invocations

### DIFF
--- a/src/main/java/com/remondis/remap/InvocationSensor.java
+++ b/src/main/java/com/remondis/remap/InvocationSensor.java
@@ -115,4 +115,11 @@ public class InvocationSensor<T> {
     return hasTrackedProperties;
   }
 
+  /**
+   * Resets the tracking state for the current thread.
+   */
+  void reset() {
+    interceptionHandler.reset();
+  }
+
 }

--- a/src/main/java/com/remondis/remap/MappingConfiguration.java
+++ b/src/main/java/com/remondis/remap/MappingConfiguration.java
@@ -540,23 +540,30 @@ public class MappingConfiguration<S, D> {
       Target target, String configurationMethod, Class<T> sensorType, TypedSelector<R, T> selector,
       boolean fluentSetters) {
     T sensor = (T) invocationSensor.getSensor();
-    // perform the selector lambda on the sensor
-    R returnValue = selector.selectField(sensor);
-    // if any property interaction was tracked...
-    if (invocationSensor.hasTrackedProperties()) {
-      // ...make sure it was exactly one property interaction
-      List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
-      denyMultipleInteractions(configurationMethod, trackedPropertyNames);
-      // get the property name
-      String propertyName = trackedPropertyNames.get(0);
-      // find the property descriptor or fail with an exception
-      PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
-      TypedPropertyDescriptor<R> tpd = new TypedPropertyDescriptor<R>();
-      tpd.returnValue = returnValue;
-      tpd.property = property;
-      return tpd;
-    } else {
-      throw zeroInteractions(configurationMethod);
+    // Defensively reset the tracking state: a previously failed selector invocation may have left tracked
+    // properties on this thread which would corrupt the evaluation of this selector.
+    invocationSensor.reset();
+    try {
+      // perform the selector lambda on the sensor
+      R returnValue = selector.selectField(sensor);
+      // if any property interaction was tracked...
+      if (invocationSensor.hasTrackedProperties()) {
+        // ...make sure it was exactly one property interaction
+        List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
+        denyMultipleInteractions(configurationMethod, trackedPropertyNames);
+        // get the property name
+        String propertyName = trackedPropertyNames.get(0);
+        // find the property descriptor or fail with an exception
+        PropertyDescriptor property = getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
+        TypedPropertyDescriptor<R> tpd = new TypedPropertyDescriptor<R>();
+        tpd.returnValue = returnValue;
+        tpd.property = property;
+        return tpd;
+      } else {
+        throw zeroInteractions(configurationMethod);
+      }
+    } finally {
+      invocationSensor.reset();
     }
   }
 
@@ -582,19 +589,26 @@ public class MappingConfiguration<S, D> {
   static <T> PropertyDescriptor getPropertyFromFieldSelector(InvocationSensor<?> invocationSensor, Target target,
       String configurationMethod, Class<T> sensorType, FieldSelector<T> selector, boolean fluentSetters) {
     T sensor = (T) invocationSensor.getSensor();
-    // perform the selector lambda on the sensor
-    selector.selectField(sensor);
-    // if any property interaction was tracked...
-    if (invocationSensor.hasTrackedProperties()) {
-      // ...make sure it was exactly one property interaction
-      List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
-      denyMultipleInteractions(configurationMethod, trackedPropertyNames);
-      // get the property name
-      String propertyName = trackedPropertyNames.get(0);
-      // find the property descriptor or fail with an exception
-      return getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
-    } else {
-      throw zeroInteractions(configurationMethod);
+    // Defensively reset the tracking state: a previously failed selector invocation may have left tracked
+    // properties on this thread which would corrupt the evaluation of this selector.
+    invocationSensor.reset();
+    try {
+      // perform the selector lambda on the sensor
+      selector.selectField(sensor);
+      // if any property interaction was tracked...
+      if (invocationSensor.hasTrackedProperties()) {
+        // ...make sure it was exactly one property interaction
+        List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
+        denyMultipleInteractions(configurationMethod, trackedPropertyNames);
+        // get the property name
+        String propertyName = trackedPropertyNames.get(0);
+        // find the property descriptor or fail with an exception
+        return getPropertyDescriptorOrFail(target, sensorType, propertyName, fluentSetters);
+      } else {
+        throw zeroInteractions(configurationMethod);
+      }
+    } finally {
+      invocationSensor.reset();
     }
   }
 

--- a/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/A.java
+++ b/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/A.java
@@ -1,0 +1,13 @@
+package com.remondis.remap.regression.staleTrackedPropertiesBug;
+
+public class A {
+  private String string;
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+}

--- a/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/B.java
+++ b/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/B.java
@@ -1,0 +1,4 @@
+package com.remondis.remap.regression.staleTrackedPropertiesBug;
+
+public class B {
+}

--- a/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/MapperTest.java
@@ -1,0 +1,37 @@
+package com.remondis.remap.regression.staleTrackedPropertiesBug;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+/**
+ * Reproduces a configuration state corruption: when a field selector threw an exception, the properties tracked up to
+ * that point remained in the thread local state of the invocation sensor, which is shared per type. The next selector
+ * evaluation on the same thread then saw the stale property in addition to its own and failed with a "multiple
+ * interactions" error.
+ */
+public class MapperTest {
+
+  @Test
+  public void shouldNotTrackPropertiesOfFailedSelectorInvocation() {
+    assertThatThrownBy(() -> Mapping.from(A.class)
+        .to(B.class)
+        .omitInSource(a -> {
+          a.getString();
+          throw new IllegalStateException("selector failure");
+        })).isInstanceOf(IllegalStateException.class);
+
+    // Without resetting the tracking state, the property tracked by the failed selector above corrupts the
+    // following configuration with a "multiple interactions" MappingException.
+    Mapper<A, B> mapper = Mapping.from(A.class)
+        .to(B.class)
+        .omitInSource(A::getString)
+        .mapper();
+
+    assertThat(mapper.map(new A())).isNotNull();
+  }
+}


### PR DESCRIPTION
When a field selector lambda threw an exception, the properties tracked up to that point remained in the thread local state of the invocation sensor, which is shared per sensed type. The next selector evaluation on the same thread then saw the stale property in addition to its own and failed with a spurious "multiple interactions" `MappingException` - or in the worst case selected the wrong property.

The tracking state is now reset defensively before each selector evaluation and in a finally block afterwards.

The regression test under `regression/staleTrackedPropertiesBug` provokes a failing selector and asserts that a subsequent configuration on the same thread is not corrupted. It fails without this change (with `multiple interactions ... properties: string,string`).

Independent of the other open PRs (based directly on develop).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)