### PR TITLE
Define sensor proxies via MethodHandles.Lookup instead of Unsafe injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <jmh.version>1.37</jmh.version>
     </properties>
     <distributionManagement>
         <repository>
@@ -177,6 +178,9 @@
                     <optimize>true</optimize>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <parameters>true</parameters>
+                    <!-- Required for the JMH annotation processor (test scope) on newer JDKs where implicit
+                        annotation processing is disabled by default. -->
+                    <proc>full</proc>
                 </configuration>
             </plugin>
 
@@ -283,6 +287,18 @@
                 <version>3.27.7</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -336,6 +352,14 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -217,11 +217,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>
-                <configuration>
-                    <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                    </argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/remondis/remap/InvocationSensor.java
+++ b/src/main/java/com/remondis/remap/InvocationSensor.java
@@ -6,8 +6,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.method.MethodDescription;
@@ -23,41 +21,52 @@ import net.bytebuddy.matcher.ElementMatcher;
  */
 public class InvocationSensor<T> {
 
-  static Map<Class<?>, InterceptionHandler<?>> interceptionHandlerCache = new ConcurrentHashMap<>();
+  /**
+   * Associates the interception handler (and thereby the generated proxy) with the sensed type. In contrast to a
+   * static map keyed by the class, a {@link ClassValue} does not prevent garbage collection of the sensed type: the
+   * handler, the generated proxy class and the sensed type form a reference cycle within the type's class loader that
+   * is collected as a whole once the class loader becomes unreachable. A strongly referencing static cache caused a
+   * class loader leak in container environments with redeploy cycles.
+   */
+  private static final ClassValue<InterceptionHandler<?>> INTERCEPTION_HANDLER_CACHE = new ClassValue<InterceptionHandler<?>>() {
+    @Override
+    protected InterceptionHandler<?> computeValue(Class<?> superType) {
+      return createInterceptionHandler(superType);
+    }
+  };
 
   private InterceptionHandler<T> interceptionHandler;
 
   /**
-   * Creates a proxy for the given class type.
+   * Creates a proxy for the given class type. The proxy is created once per type and cached for the lifetime of the
+   * type.
    *
    * @param superType the class type for which the proxy should be created
    */
+  @SuppressWarnings("unchecked")
   public InvocationSensor(Class<T> superType) {
+    this.interceptionHandler = (InterceptionHandler<T>) INTERCEPTION_HANDLER_CACHE.get(superType);
+  }
+
+  private static <T> InterceptionHandler<T> createInterceptionHandler(Class<T> superType) {
     ClassLoader classLoader;
-    if (isNull(superType) || isNull(superType.getClassLoader())) {
+    if (isNull(superType.getClassLoader())) {
       classLoader = getSystemClassLoader();
     } else {
       classLoader = superType.getClassLoader();
     }
     try {
-      if (interceptionHandlerCache.containsKey(superType)) {
-        this.interceptionHandler = (InterceptionHandler<T>) interceptionHandlerCache.get(superType);
-      } else {
-        InterceptionHandler<T> interceptionHandler = new InterceptionHandler<>();
-        T po = null;
-        po = new ByteBuddy().subclass(superType)
-            .method(isDeclaredByClassHierarchy(superType))
-            .intercept(MethodDelegation.to(interceptionHandler))
-            .make()
-            .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
-            .getLoaded()
-            .getDeclaredConstructor()
-            .newInstance();
-        interceptionHandler.setProxyObject(po);
-        interceptionHandlerCache.put(superType, interceptionHandler);
-        this.interceptionHandler = interceptionHandler;
-      }
-
+      InterceptionHandler<T> interceptionHandler = new InterceptionHandler<>();
+      T po = new ByteBuddy().subclass(superType)
+          .method(isDeclaredByClassHierarchy(superType))
+          .intercept(MethodDelegation.to(interceptionHandler))
+          .make()
+          .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
+          .getLoaded()
+          .getDeclaredConstructor()
+          .newInstance();
+      interceptionHandler.setProxyObject(po);
+      return interceptionHandler;
     } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
       throw new MappingException(
           String.format("Error while creating proxy for class '%s'", superType.getCanonicalName()), ex);
@@ -71,7 +80,7 @@ public class InvocationSensor<T> {
    * @param type type to get the junction for
    * @return the junction with all superclasses and interfaces including the given typeD
    */
-  private ElementMatcher.Junction<MethodDescription> isDeclaredByClassHierarchy(Class<T> type) {
+  private static <T> ElementMatcher.Junction<MethodDescription> isDeclaredByClassHierarchy(Class<T> type) {
     ClassHierarchyIterator classHierarchyIterator = new ClassHierarchyIterator(type);
     ElementMatcher.Junction<MethodDescription> methodDescriptionJunction = null;
     while (classHierarchyIterator.hasNext()) {

--- a/src/main/java/com/remondis/remap/InvocationSensor.java
+++ b/src/main/java/com/remondis/remap/InvocationSensor.java
@@ -4,6 +4,7 @@ import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.util.Objects.isNull;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class InvocationSensor<T> {
           .method(isDeclaredByClassHierarchy(superType))
           .intercept(MethodDelegation.to(interceptionHandler))
           .make()
-          .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
+          .load(classLoader, classLoadingStrategy(superType))
           .getLoaded()
           .getDeclaredConstructor()
           .newInstance();
@@ -70,6 +71,22 @@ public class InvocationSensor<T> {
     } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
       throw new MappingException(
           String.format("Error while creating proxy for class '%s'", superType.getCanonicalName()), ex);
+    }
+  }
+
+  /**
+   * Returns the class loading strategy for the proxy class. The proxy is defined via a {@link MethodHandles.Lookup},
+   * which is the supported way to define classes since Java 9. The formerly used
+   * {@link ClassLoadingStrategy.Default#INJECTION} relies on JDK internals and required
+   * <code>--add-opens java.base/java.lang=ALL-UNNAMED</code> on current JDKs. If the sensed type's package is not
+   * accessible (e.g. a type of a named module that does not open its package to ReMap), the proxy is loaded into a
+   * wrapper class loader instead.
+   */
+  private static ClassLoadingStrategy<ClassLoader> classLoadingStrategy(Class<?> superType) {
+    try {
+      return ClassLoadingStrategy.UsingLookup.of(MethodHandles.privateLookupIn(superType, MethodHandles.lookup()));
+    } catch (IllegalAccessException | SecurityException e) {
+      return ClassLoadingStrategy.Default.WRAPPER;
     }
   }
 

--- a/src/test/java/com/remondis/remap/InvocationSensorClassLoaderLeakTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorClassLoaderLeakTest.java
@@ -1,0 +1,79 @@
+package com.remondis.remap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the class loader leak caused by the former static proxy cache of {@link InvocationSensor}: the
+ * cache held strong references to every sensed type and its generated proxy, so the class loader of a mapped type
+ * (e.g. a web application class loader) could never be garbage collected.
+ */
+public class InvocationSensorClassLoaderLeakTest {
+
+  private static final String BEAN_CLASS_NAME = "com.remondis.remap.LeakTestBean";
+
+  @Test
+  public void shouldNotPreventClassLoaderGarbageCollection() throws Exception {
+    URL testClasses = Paths.get("target", "test-classes")
+        .toUri()
+        .toURL();
+    BeanFirstClassLoader loader = new BeanFirstClassLoader(new URL[] {
+        testClasses
+    }, getClass().getClassLoader());
+
+    Class<?> foreignBean = loader.loadClass(BEAN_CLASS_NAME);
+    assertThat(foreignBean.getClassLoader()).isSameAs(loader);
+
+    InvocationSensor<?> invocationSensor = new InvocationSensor<>(foreignBean);
+    assertThat(invocationSensor.getSensor()).isInstanceOf(foreignBean);
+
+    WeakReference<ClassLoader> loaderReference = new WeakReference<>(loader);
+    loader.close();
+    loader = null;
+    foreignBean = null;
+    invocationSensor = null;
+
+    for (int i = 0; i < 50 && loaderReference.get() != null; i++) {
+      System.gc();
+      Thread.sleep(50);
+    }
+    assertThat(loaderReference.get())
+        .as("The InvocationSensor must not prevent garbage collection of the sensed type's class loader.")
+        .isNull();
+  }
+
+  /**
+   * Loads the leak test bean itself instead of delegating to the parent, so the bean class is owned by this
+   * throwaway class loader. All other classes (ReMap, JDK) are delegated to the parent, which mirrors a container
+   * setup where the mapped beans live in an application class loader while the library is provided by a parent.
+   */
+  private static class BeanFirstClassLoader extends URLClassLoader {
+
+    BeanFirstClassLoader(URL[] urls, ClassLoader parent) {
+      super(urls, parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      if (BEAN_CLASS_NAME.equals(name)) {
+        synchronized (getClassLoadingLock(name)) {
+          Class<?> loaded = findLoadedClass(name);
+          if (loaded == null) {
+            loaded = findClass(name);
+          }
+          if (resolve) {
+            resolveClass(loaded);
+          }
+          return loaded;
+        }
+      }
+      return super.loadClass(name, resolve);
+    }
+  }
+}

--- a/src/test/java/com/remondis/remap/InvocationSensorTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorTest.java
@@ -1,22 +1,15 @@
 package com.remondis.remap;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
-import org.junit.Before;
 import org.junit.Test;
 
 public class InvocationSensorTest {
-
-  @Before
-  public void setup() {
-    InvocationSensor.interceptionHandlerCache.clear();
-  }
 
   @Test
   public void shouldCacheThreadSafe() {
@@ -26,8 +19,6 @@ public class InvocationSensorTest {
 
     Semaphore s2 = new Semaphore(1);
     s2.acquireUninterruptibly();
-
-    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(DummyDto.class);
 
     Thread t1 = new Thread(new Runnable() {
 
@@ -52,33 +43,33 @@ public class InvocationSensorTest {
 
   @Test
   public void shouldCache() {
-    assertTrue(InvocationSensor.interceptionHandlerCache.isEmpty());
+    InvocationSensor<DummyDto> first = new InvocationSensor<>(DummyDto.class);
+    InvocationSensor<DummyDto> second = new InvocationSensor<>(DummyDto.class);
+    // The proxy is created once per type and cached, so all sensors of a type share the same proxy instance.
+    assertSame(first.getSensor(), second.getSensor());
+  }
+
+  @Test
+  public void shouldTrackInvocations() {
     InvocationSensor<DummyDto> invocationSensor = new InvocationSensor<>(DummyDto.class);
-    assertFalse(InvocationSensor.interceptionHandlerCache.isEmpty());
-    assertTrue(InvocationSensor.interceptionHandlerCache.containsKey(DummyDto.class));
-    assertNotNull(InvocationSensor.interceptionHandlerCache.get(DummyDto.class));
-
-    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(DummyDto.class);
-
     DummyDto sensor = invocationSensor.getSensor();
-    sensor.getString();
 
-    List<String> trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    sensor.getString();
+    List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
     assertEquals(1, trackedPropertyNames.size());
     assertTrue(trackedPropertyNames.contains("string"));
 
     sensor.getAnotherString();
-    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
     assertEquals(1, trackedPropertyNames.size());
     assertTrue(trackedPropertyNames.contains("anotherString"));
 
     sensor.getString();
     sensor.getAnotherString();
-    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
     assertEquals(2, trackedPropertyNames.size());
     assertTrue(trackedPropertyNames.contains("string"));
     assertTrue(trackedPropertyNames.contains("anotherString"));
-
   }
 
 }

--- a/src/test/java/com/remondis/remap/LeakTestBean.java
+++ b/src/test/java/com/remondis/remap/LeakTestBean.java
@@ -1,0 +1,17 @@
+package com.remondis.remap;
+
+/**
+ * A bean that is loaded in a throwaway class loader by the class loader leak regression test. This class must only
+ * depend on <code>java.*</code> types.
+ */
+public class LeakTestBean {
+  private String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/Address.java
+++ b/src/test/java/com/remondis/remap/benchmark/Address.java
@@ -1,0 +1,40 @@
+package com.remondis.remap.benchmark;
+
+public class Address {
+  private String street;
+  private String city;
+  private String zipCode;
+  private int number;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+
+  public void setNumber(int number) {
+    this.number = number;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/AddressDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/AddressDto.java
@@ -1,0 +1,40 @@
+package com.remondis.remap.benchmark;
+
+public class AddressDto {
+  private String street;
+  private String city;
+  private String zipCode;
+  private int number;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getNumber() {
+    return number;
+  }
+
+  public void setNumber(int number) {
+    this.number = number;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
@@ -1,0 +1,37 @@
+package com.remondis.remap.benchmark;
+
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Runs the ReMap JMH benchmarks. Results are printed to the console and written to
+ * <code>target/jmh-result.json</code>.
+ *
+ * <p>
+ * The benchmark JVMs forked by JMH require the test classpath on <code>java.class.path</code>, so the runner must be
+ * started with a plain <code>java</code> command instead of <code>exec:java</code>:
+ *
+ * <pre>
+ * mvn test-compile dependency:build-classpath -Dmdep.outputFile=target/classpath.txt -Dmdep.includeScope=test
+ * java -cp "target/classes:target/test-classes:$(cat target/classpath.txt)" \
+ *     com.remondis.remap.benchmark.BenchmarkRunner
+ * </pre>
+ *
+ * (On Windows use <code>;</code> as path separator.) An optional first argument is used as benchmark include regex,
+ * e.g. <code>mapCollections</code>.
+ * </p>
+ */
+public class BenchmarkRunner {
+
+  public static void main(String[] args) throws RunnerException {
+    Options options = new OptionsBuilder().include(args.length > 0 ? args[0] : MappingBenchmark.class.getSimpleName())
+        .jvmArgsAppend("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+        .resultFormat(ResultFormatType.JSON)
+        .result("target/jmh-result.json")
+        .build();
+    new Runner(options).run();
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/remondis/remap/benchmark/BenchmarkRunner.java
@@ -28,7 +28,6 @@ public class BenchmarkRunner {
 
   public static void main(String[] args) throws RunnerException {
     Options options = new OptionsBuilder().include(args.length > 0 ? args[0] : MappingBenchmark.class.getSimpleName())
-        .jvmArgsAppend("--add-opens", "java.base/java.lang=ALL-UNNAMED")
         .resultFormat(ResultFormatType.JSON)
         .result("target/jmh-result.json")
         .build();

--- a/src/test/java/com/remondis/remap/benchmark/Container.java
+++ b/src/test/java/com/remondis/remap/benchmark/Container.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+
+public class Container {
+  private List<String> tags;
+  private List<Address> addresses;
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<Address> getAddresses() {
+    return addresses;
+  }
+
+  public void setAddresses(List<Address> addresses) {
+    this.addresses = addresses;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/ContainerDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/ContainerDto.java
@@ -1,0 +1,24 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+
+public class ContainerDto {
+  private List<String> tags;
+  private List<AddressDto> addresses;
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<AddressDto> getAddresses() {
+    return addresses;
+  }
+
+  public void setAddresses(List<AddressDto> addresses) {
+    this.addresses = addresses;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/FlatDestination.java
+++ b/src/test/java/com/remondis/remap/benchmark/FlatDestination.java
@@ -1,0 +1,94 @@
+package com.remondis.remap.benchmark;
+
+public class FlatDestination {
+  private long id;
+  private String firstName;
+  private String lastName;
+  private String street;
+  private String city;
+  private String zipCode;
+  private int age;
+  private boolean active;
+  private double score;
+  private Integer loginCount;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  public Integer getLoginCount() {
+    return loginCount;
+  }
+
+  public void setLoginCount(Integer loginCount) {
+    this.loginCount = loginCount;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/FlatSource.java
+++ b/src/test/java/com/remondis/remap/benchmark/FlatSource.java
@@ -1,0 +1,94 @@
+package com.remondis.remap.benchmark;
+
+public class FlatSource {
+  private long id;
+  private String firstName;
+  private String lastName;
+  private String street;
+  private String city;
+  private String zipCode;
+  private int age;
+  private boolean active;
+  private double score;
+  private Integer loginCount;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  public Integer getLoginCount() {
+    return loginCount;
+  }
+
+  public void setLoginCount(Integer loginCount) {
+    this.loginCount = loginCount;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/MappingBenchmark.java
+++ b/src/test/java/com/remondis/remap/benchmark/MappingBenchmark.java
@@ -1,0 +1,153 @@
+package com.remondis.remap.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+
+/**
+ * JMH benchmarks covering the mapping hot paths of ReMap:
+ * <ul>
+ * <li>{@link #mapFlatBean(MapperState)}: implicit mapping of a flat bean with 10 properties.</li>
+ * <li>{@link #mapNestedBean(MapperState)}: mapping with a nested object using a registered mapper.</li>
+ * <li>{@link #mapNestedBeanConcurrent(MapperState)}: same as above, but with 4 threads sharing one mapper
+ * instance.</li>
+ * <li>{@link #mapCollections(CollectionState)}: mapping of collections (reference elements and nested mapping per
+ * element).</li>
+ * <li>{@link #createMapper(MapperState)}: mapper creation (configuration time).</li>
+ * </ul>
+ * See {@link BenchmarkRunner} for how to run the benchmarks.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class MappingBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class MapperState {
+    Mapper<FlatSource, FlatDestination> flatMapper;
+    Mapper<Address, AddressDto> addressMapper;
+    Mapper<Person, PersonDto> personMapper;
+
+    FlatSource flatSource;
+    Person person;
+
+    @Setup
+    public void setup() {
+      flatMapper = Mapping.from(FlatSource.class)
+          .to(FlatDestination.class)
+          .mapper();
+      addressMapper = Mapping.from(Address.class)
+          .to(AddressDto.class)
+          .mapper();
+      personMapper = Mapping.from(Person.class)
+          .to(PersonDto.class)
+          .useMapper(addressMapper)
+          .mapper();
+
+      flatSource = new FlatSource();
+      flatSource.setId(4711L);
+      flatSource.setFirstName("John");
+      flatSource.setLastName("Doe");
+      flatSource.setStreet("Main Street");
+      flatSource.setCity("Springfield");
+      flatSource.setZipCode("12345");
+      flatSource.setAge(42);
+      flatSource.setActive(true);
+      flatSource.setScore(0.75d);
+      flatSource.setLoginCount(1337);
+
+      person = new Person();
+      person.setName("John Doe");
+      person.setAge(42);
+      person.setAddress(newAddress(1));
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class CollectionState {
+    @Param({
+        "10", "1000"
+    })
+    int collectionSize;
+
+    Mapper<Container, ContainerDto> containerMapper;
+    Container container;
+
+    @Setup
+    public void setup() {
+      Mapper<Address, AddressDto> addressMapper = Mapping.from(Address.class)
+          .to(AddressDto.class)
+          .mapper();
+      containerMapper = Mapping.from(Container.class)
+          .to(ContainerDto.class)
+          .useMapper(addressMapper)
+          .mapper();
+
+      container = new Container();
+      container.setTags(IntStream.range(0, collectionSize)
+          .mapToObj(i -> "tag-" + i)
+          .collect(Collectors.toList()));
+      List<Address> addresses = IntStream.range(0, collectionSize)
+          .mapToObj(MappingBenchmark::newAddress)
+          .collect(Collectors.toList());
+      container.setAddresses(addresses);
+    }
+  }
+
+  @Benchmark
+  public FlatDestination mapFlatBean(MapperState state) {
+    return state.flatMapper.map(state.flatSource);
+  }
+
+  @Benchmark
+  public PersonDto mapNestedBean(MapperState state) {
+    return state.personMapper.map(state.person);
+  }
+
+  @Benchmark
+  @Threads(4)
+  public PersonDto mapNestedBeanConcurrent(MapperState state) {
+    return state.personMapper.map(state.person);
+  }
+
+  @Benchmark
+  public ContainerDto mapCollections(CollectionState state) {
+    return state.containerMapper.map(state.container);
+  }
+
+  @Benchmark
+  public Mapper<Person, PersonDto> createMapper(MapperState state) {
+    return Mapping.from(Person.class)
+        .to(PersonDto.class)
+        .useMapper(state.addressMapper)
+        .mapper();
+  }
+
+  static Address newAddress(int i) {
+    Address address = new Address();
+    address.setStreet("Street " + i);
+    address.setCity("City " + i);
+    address.setZipCode(String.valueOf(10000 + i));
+    address.setNumber(i);
+    return address;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/Person.java
+++ b/src/test/java/com/remondis/remap/benchmark/Person.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.benchmark;
+
+public class Person {
+  private String name;
+  private int age;
+  private Address address;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+}

--- a/src/test/java/com/remondis/remap/benchmark/PersonDto.java
+++ b/src/test/java/com/remondis/remap/benchmark/PersonDto.java
@@ -1,0 +1,31 @@
+package com.remondis.remap.benchmark;
+
+public class PersonDto {
+  private String name;
+  private int age;
+  private AddressDto address;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public AddressDto getAddress() {
+    return address;
+  }
+
+  public void setAddress(AddressDto address) {
+    this.address = address;
+  }
+}


### PR DESCRIPTION
The invocation sensor proxies were loaded with `ClassLoadingStrategy.Default.INJECTION`, which relies on JDK internals (`sun.misc.Unsafe` / reflective `ClassLoader` access) and required `--add-opens java.base/java.lang=ALL-UNNAMED` on current JDKs. Consumers of ReMap inherited this JVM flag requirement, and the internals used by `INJECTION` are being phased out of the JDK.

The proxy class is now defined via `MethodHandles.privateLookupIn(sensedType, lookup())` with `ClassLoadingStrategy.UsingLookup` - the supported API for class definition since Java 9. If a type of a named module does not open its package to ReMap, the proxy falls back to a wrapper class loader instead of failing.

The `--add-opens` flag is removed from the surefire configuration and the JMH benchmark runner. **The full test suite runs without it** (199 tests green), including the two cases where this migration typically breaks:

- `VisibilityTest`: package-private bean classes - `privateLookupIn` provides full access in the target package, the proxy is defined there.
- `InvocationSensorClassLoaderLeakTest`: bean in a throwaway class loader - the lookup defines the proxy in the bean's class loader, which stays garbage collectable.

**Depends on #180** (stacked on it; shows the commits of #177/#180 until they are merged). Note for #172 (records): its integration state includes the pre-migration `InvocationSensor`; I will refresh that branch once this PR is merged, the conflict is small.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)