### PR TITLE
Migrate to JUnit 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,13 +255,7 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.12.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>5.12.2</version>
+                <version>6.1.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -331,10 +325,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/com/remondis/extern/usecase/metamodel/MetaModelFeatureTest.java
+++ b/src/test/java/com/remondis/extern/usecase/metamodel/MetaModelFeatureTest.java
@@ -16,10 +16,10 @@ import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingModel;
 import com.remondis.remap.MappingOperation;
 
-public class MetaModelFeatureTest {
+class MetaModelFeatureTest {
 
   @Test
-  public void shouldGetSourceFieldByFieldSelector() {
+  void shouldGetSourceFieldByFieldSelector() {
     Mapper<Source, Destination> mapper = getMapper();
     MappingModel<Source, Destination> model = mapper.getMappingModel();
     MappingModel<Source, Destination>.TransformationSearchResult result = model.findMappingBySource(Source::getNested);
@@ -34,7 +34,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldPerformObjectTransformation() {
+  void shouldPerformObjectTransformation() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> destPredicate = nameEqualsPredicate("nested");
@@ -59,7 +59,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldSetTransformation() {
+  void shouldSetTransformation() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> destPredicate = nameEqualsPredicate("doesNotExistInSource");
@@ -79,7 +79,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldGetOmitInDest() {
+  void shouldGetOmitInDest() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> destPredicate = nameEqualsPredicate("omitInDestination");
@@ -97,7 +97,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldGetOmitInSource() {
+  void shouldGetOmitInSource() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> sourcePredicate = nameEqualsPredicate("omitInSource");
@@ -115,7 +115,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldGetBySource_multiMatch() {
+  void shouldGetBySource_multiMatch() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> sourcePredicate = nameEqualsPredicate("string");
@@ -132,7 +132,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldGetByDest_singleMatch() {
+  void shouldGetByDest_singleMatch() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> destPredicate = nameEqualsPredicate("stringRename");
@@ -151,7 +151,7 @@ public class MetaModelFeatureTest {
   }
 
   @Test
-  public void shouldGetBySourceAndDest_singleMatch() {
+  void shouldGetBySourceAndDest_singleMatch() {
     Mapper<Source, Destination> mapper = getMapper();
 
     Predicate<String> sourcePredicate = nameEqualsPredicate("string");

--- a/src/test/java/com/remondis/extern/usecase/metamodel/MetaModelFeatureTest.java
+++ b/src/test/java/com/remondis/extern/usecase/metamodel/MetaModelFeatureTest.java
@@ -2,13 +2,13 @@ package com.remondis.extern.usecase.metamodel;
 
 import static com.remondis.remap.MappingModel.nameEqualsPredicate;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.MappedResult;
 import com.remondis.remap.Mapper;
@@ -210,8 +210,8 @@ public class MetaModelFeatureTest {
   }
 
   private void assertSingleResult(MappingModel<Source, Destination>.TransformationSearchResult mappingModel) {
-    assertTrue("Mapping model should have a single result!", mappingModel.hasSingleResult());
-    assertFalse("Mapping model should not have multiple results!", mappingModel.hasMultipleResults());
+    assertTrue(mappingModel.hasSingleResult(), "Mapping model should have a single result!");
+    assertFalse(mappingModel.hasMultipleResults(), "Mapping model should not have multiple results!");
   }
 
   private void assertMappingValue(MappedResult mappedResult, Object expectedValue) {
@@ -220,15 +220,15 @@ public class MetaModelFeatureTest {
   }
 
   private void assertMappingHasValue(MappedResult mappedResult) {
-    assertTrue("Mapping result should have a value!", mappedResult.hasValue());
+    assertTrue(mappedResult.hasValue(), "Mapping result should have a value!");
   }
 
   private void assertResult(MappingModel<Source, Destination>.TransformationSearchResult mappingModel) {
-    assertTrue("Mapping model should have a result!", mappingModel.hasResult());
+    assertTrue(mappingModel.hasResult(), "Mapping model should have a result!");
   }
 
   private void assertMultiResult(MappingModel<Source, Destination>.TransformationSearchResult mappingModel) {
-    assertFalse("Mapping model should have multiple results!", mappingModel.hasSingleResult());
+    assertFalse(mappingModel.hasSingleResult(), "Mapping model should have multiple results!");
   }
 
 }

--- a/src/test/java/com/remondis/remap/BiRecursivePropertyWalkerTest.java
+++ b/src/test/java/com/remondis/remap/BiRecursivePropertyWalkerTest.java
@@ -1,11 +1,11 @@
 package com.remondis.remap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.basic.A;
 import com.remondis.remap.basic.B;

--- a/src/test/java/com/remondis/remap/BiRecursivePropertyWalkerTest.java
+++ b/src/test/java/com/remondis/remap/BiRecursivePropertyWalkerTest.java
@@ -13,10 +13,10 @@ import com.remondis.remap.utils.propertywalker.BiRecursivePropertyWalker;
 import com.remondis.remap.utils.propertywalker.PropertyAccess;
 import com.remondis.remap.utils.propertywalker.VisitorFunction;
 
-public class BiRecursivePropertyWalkerTest {
+class BiRecursivePropertyWalkerTest {
 
   @Test
-  public void shouldTraverseProperties() {
+  void shouldTraverseProperties() {
     Function<A, String> getter = A::getString;
     BiConsumer<A, String> setter = A::setString;
 

--- a/src/test/java/com/remondis/remap/InvocationSensorClassLoaderLeakTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorClassLoaderLeakTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test;
  * cache held strong references to every sensed type and its generated proxy, so the class loader of a mapped type
  * (e.g. a web application class loader) could never be garbage collected.
  */
-public class InvocationSensorClassLoaderLeakTest {
+class InvocationSensorClassLoaderLeakTest {
 
   private static final String BEAN_CLASS_NAME = "com.remondis.remap.LeakTestBean";
 
   @Test
-  public void shouldNotPreventClassLoaderGarbageCollection() throws Exception {
+  void shouldNotPreventClassLoaderGarbageCollection() throws Exception {
     URL testClasses = Paths.get("target", "test-classes")
         .toUri()
         .toURL();

--- a/src/test/java/com/remondis/remap/InvocationSensorTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorTest.java
@@ -9,10 +9,10 @@ import java.util.concurrent.Semaphore;
 
 import org.junit.jupiter.api.Test;
 
-public class InvocationSensorTest {
+class InvocationSensorTest {
 
   @Test
-  public void shouldCacheThreadSafe() {
+  void shouldCacheThreadSafe() {
 
     Semaphore s1 = new Semaphore(1);
     s1.acquireUninterruptibly();
@@ -42,7 +42,7 @@ public class InvocationSensorTest {
   }
 
   @Test
-  public void shouldCache() {
+  void shouldCache() {
     InvocationSensor<DummyDto> first = new InvocationSensor<>(DummyDto.class);
     InvocationSensor<DummyDto> second = new InvocationSensor<>(DummyDto.class);
     // The proxy is created once per type and cached, so all sensors of a type share the same proxy instance.
@@ -50,7 +50,7 @@ public class InvocationSensorTest {
   }
 
   @Test
-  public void shouldTrackInvocations() {
+  void shouldTrackInvocations() {
     InvocationSensor<DummyDto> invocationSensor = new InvocationSensor<>(DummyDto.class);
     DummyDto sensor = invocationSensor.getSensor();
 

--- a/src/test/java/com/remondis/remap/InvocationSensorTest.java
+++ b/src/test/java/com/remondis/remap/InvocationSensorTest.java
@@ -1,13 +1,13 @@
 package com.remondis.remap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InvocationSensorTest {
 

--- a/src/test/java/com/remondis/remap/MapperTest.java
+++ b/src/test/java/com/remondis/remap/MapperTest.java
@@ -1,17 +1,17 @@
 package com.remondis.remap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This is the test of class {@link Mapper}.
@@ -20,7 +20,7 @@ public class MapperTest {
 
   private Mapper<StringDto, StringDto> mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.mapper = Mapping.from(StringDto.class)
         .to(StringDto.class)

--- a/src/test/java/com/remondis/remap/MapperTest.java
+++ b/src/test/java/com/remondis/remap/MapperTest.java
@@ -16,37 +16,37 @@ import org.junit.jupiter.api.Test;
 /**
  * This is the test of class {@link Mapper}.
  */
-public class MapperTest {
+class MapperTest {
 
   private Mapper<StringDto, StringDto> mapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.mapper = Mapping.from(StringDto.class)
         .to(StringDto.class)
         .mapper();
   }
 
   @Test
-  public void shouldMapEmptyList() {
+  void shouldMapEmptyList() {
     List<StringDto> list = mapper.map(Collections.emptyList());
     assertTrue(list.isEmpty());
   }
 
   @Test
-  public void shouldMapEmptySet() {
+  void shouldMapEmptySet() {
     Set<StringDto> list = mapper.map(Collections.emptySet());
     assertTrue(list.isEmpty());
   }
 
   @Test
-  public void shouldMapNull() {
+  void shouldMapNull() {
     StringDto returnValue = mapper.mapOptional(null);
     assertNull(returnValue);
   }
 
   @Test
-  public void shouldMapOptional() {
+  void shouldMapOptional() {
     String expectedString = "string";
     StringDto returnValue = mapper.mapOptional(new StringDto(expectedString));
     assertNotNull(returnValue);
@@ -54,7 +54,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldMapDefault() {
+  void shouldMapDefault() {
     String expectedString = "string";
     StringDto expectedA = new StringDto(expectedString);
     StringDto returnValue = mapper.mapOrDefault(null, expectedA);
@@ -63,7 +63,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldNotMapDefault() {
+  void shouldNotMapDefault() {
     String expectedString = "string";
     StringDto expectedA = new StringDto(expectedString);
     StringDto notExpectedDefault = new StringDto("someOtherString");

--- a/src/test/java/com/remondis/remap/PropertiesTest.java
+++ b/src/test/java/com/remondis/remap/PropertiesTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 import com.remondis.remap.fluent.FluentSetterDto;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
-public class PropertiesTest {
+class PropertiesTest {
 
   @Test
-  public void a() {
+  void a() {
     Optional<PropertyDescriptor> pdFluentSetterNotThere = getProperties(FluentSetterDto.class, DESTINATION, false)
         .stream()
         .filter(pd -> pd.getName()
@@ -28,7 +28,7 @@ public class PropertiesTest {
   }
 
   @Test
-  public void b() {
+  void b() {
     // Changes the property descriptor persistently (vm-wide?).
     // Some cache is working here
     Optional<PropertyDescriptor> pdFluentSetter = getProperties(FluentSetterDto.class, DESTINATION, true).stream()
@@ -40,7 +40,7 @@ public class PropertiesTest {
   }
 
   @Test
-  public void c() {
+  void c() {
     Optional<PropertyDescriptor> pdFluentSetter = getProperties(FluentSetterDto.class, DESTINATION, false).stream()
         .filter(pd -> pd.getName()
             .equals("b1"))
@@ -50,7 +50,7 @@ public class PropertiesTest {
   }
 
   @Test
-  public void extendedClassDoesNotImplementsInterface() {
+  void extendedClassDoesNotImplementsInterface() {
     // given
     // when
     getProperties(InternalDummyB.class, DESTINATION, false); // fill cache with correct values
@@ -70,7 +70,7 @@ public class PropertiesTest {
   }
 
   @Test
-  public void interfaceIsNotFullyMapable() {
+  void interfaceIsNotFullyMapable() {
     // given
     // when
     PropertyDescriptor actual = getProperties(InternalDummyA.class, DESTINATION, false).stream()
@@ -88,7 +88,7 @@ public class PropertiesTest {
   }
 
   @Test
-  public void interfaceUsesGenericType() {
+  void interfaceUsesGenericType() {
     try {
       getProperties(InternalDummyC.class, DESTINATION, false);
     } catch (Exception e) {

--- a/src/test/java/com/remondis/remap/PropertiesTest.java
+++ b/src/test/java/com/remondis/remap/PropertiesTest.java
@@ -2,20 +2,19 @@ package com.remondis.remap;
 
 import static com.remondis.remap.Properties.getProperties;
 import static com.remondis.remap.Target.DESTINATION;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.beans.PropertyDescriptor;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import com.remondis.remap.fluent.FluentSetterDto;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class PropertiesTest {
 
   @Test

--- a/src/test/java/com/remondis/remap/assertion/omitOthersAssert/OmitOthersAssertionTest.java
+++ b/src/test/java/com/remondis/remap/assertion/omitOthersAssert/OmitOthersAssertionTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.assertion.omitOthersAssert;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/assertion/omitOthersAssert/OmitOthersAssertionTest.java
+++ b/src/test/java/com/remondis/remap/assertion/omitOthersAssert/OmitOthersAssertionTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class OmitOthersAssertionTest {
+class OmitOthersAssertionTest {
 
   @Test
-  public void shouldComplainAboutUnexpectedOmitsForDestination() {
+  void shouldComplainAboutUnexpectedOmitsForDestination() {
     Mapper<BeanEmpty, BeanWithFields> mapper = Mapping.from(BeanEmpty.class)
         .to(BeanWithFields.class)
         .omitOtherDestinationProperties()
@@ -24,7 +24,7 @@ public class OmitOthersAssertionTest {
   }
 
   @Test
-  public void shouldComplainAboutUnexpectedOmitsForSource() {
+  void shouldComplainAboutUnexpectedOmitsForSource() {
     Mapper<BeanWithFields, BeanEmpty> mapper = Mapping.from(BeanWithFields.class)
         .to(BeanEmpty.class)
         .omitOtherSourceProperties()

--- a/src/test/java/com/remondis/remap/basic/AssertMappingTest.java
+++ b/src/test/java/com/remondis/remap/basic/AssertMappingTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.basic;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertConfiguration;
 import com.remondis.remap.AssertMapping;
@@ -341,7 +341,7 @@ public class AssertMappingTest {
 
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void shouldDetectExpectedNoSkipWhenNull() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
@@ -365,10 +365,10 @@ public class AssertMappingTest {
         .andTest(String::valueOf)
         .expectOmitInSource(A::getOmitted)
         .expectOmitInDestination(AResource::getOmitted);
-    asserts.ensure();
+    assertThatThrownBy(asserts::ensure).isInstanceOf(AssertionError.class);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void shouldDetectExpectedSkipWhenNull() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
@@ -392,7 +392,7 @@ public class AssertMappingTest {
         .andSkipWhenNull()
         .expectOmitInSource(A::getOmitted)
         .expectOmitInDestination(AResource::getOmitted);
-    asserts.ensure();
+    assertThatThrownBy(asserts::ensure).isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/src/test/java/com/remondis/remap/basic/AssertMappingTest.java
+++ b/src/test/java/com/remondis/remap/basic/AssertMappingTest.java
@@ -13,10 +13,10 @@ import com.remondis.remap.assertion.AResource;
 import com.remondis.remap.assertion.B;
 import com.remondis.remap.assertion.BResource;
 
-public class AssertMappingTest {
+class AssertMappingTest {
 
   @Test
-  public void shouldDenyIllegalArguments() {
+  void shouldDenyIllegalArguments() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -99,7 +99,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldThrowExceptionOfFunctionAsCause() {
+  void shouldThrowExceptionOfFunctionAsCause() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .mapper();
@@ -131,7 +131,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void regression_checkTransformationAgainstNullCausesWrongExceptionMessage() {
+  void regression_checkTransformationAgainstNullCausesWrongExceptionMessage() {
     // There was a bug that causes an AssertionException with a wrong operation name
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -165,7 +165,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldThrowAssertionError_multipleAssertsOperationsInvolvingSameDestinationFields() {
+  void shouldThrowAssertionError_multipleAssertsOperationsInvolvingSameDestinationFields() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -214,7 +214,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldThrowAssertionError_multipleAssertsOfOneOperation() {
+  void shouldThrowAssertionError_multipleAssertsOfOneOperation() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -342,7 +342,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldDetectExpectedNoSkipWhenNull() {
+  void shouldDetectExpectedNoSkipWhenNull() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -369,7 +369,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldDetectExpectedSkipWhenNull() {
+  void shouldDetectExpectedSkipWhenNull() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -396,7 +396,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldThrowAssertionError_missingAsserts() {
+  void shouldThrowAssertionError_missingAsserts() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .mapper();
@@ -453,7 +453,7 @@ public class AssertMappingTest {
   }
 
   @Test
-  public void shouldNotThrowAssertionError() {
+  void shouldNotThrowAssertionError() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/basic/FlatCollectionMappingTest.java
+++ b/src/test/java/com/remondis/remap/basic/FlatCollectionMappingTest.java
@@ -2,15 +2,15 @@ package com.remondis.remap.basic;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/basic/FlatCollectionMappingTest.java
+++ b/src/test/java/com/remondis/remap/basic/FlatCollectionMappingTest.java
@@ -19,10 +19,10 @@ import com.remondis.remap.flatCollectionMapping.Destination;
 import com.remondis.remap.flatCollectionMapping.Id;
 import com.remondis.remap.flatCollectionMapping.Source;
 
-public class FlatCollectionMappingTest {
+class FlatCollectionMappingTest {
 
   @Test
-  public void shouldMapCollectionByFunction() {
+  void shouldMapCollectionByFunction() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)
@@ -43,7 +43,7 @@ public class FlatCollectionMappingTest {
   }
 
   @Test
-  public void shouldDetectIllegalArguments() {
+  void shouldDetectIllegalArguments() {
     assertThatThrownBy(() -> {
       Mapping.from(Source.class)
           .to(Destination.class)
@@ -68,7 +68,7 @@ public class FlatCollectionMappingTest {
   }
 
   @Test
-  public void shouldNotSkipNullItems() {
+  void shouldNotSkipNullItems() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)
@@ -92,7 +92,7 @@ public class FlatCollectionMappingTest {
   }
 
   @Test
-  public void shouldSkipNullItems() {
+  void shouldSkipNullItems() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)
@@ -114,7 +114,7 @@ public class FlatCollectionMappingTest {
   }
 
   @Test
-  public void nullCollection() {
+  void nullCollection() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)
@@ -127,7 +127,7 @@ public class FlatCollectionMappingTest {
   }
 
   @Test
-  public void shouldDetectDifferentNullStrategy() {
+  void shouldDetectDifferentNullStrategy() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)

--- a/src/test/java/com/remondis/remap/basic/MapIterableTest.java
+++ b/src/test/java/com/remondis/remap/basic/MapIterableTest.java
@@ -8,14 +8,14 @@ import static com.remondis.remap.basic.MapperTest.MORE_IN_A;
 import static com.remondis.remap.basic.MapperTest.NUMBER;
 import static com.remondis.remap.basic.MapperTest.STRING;
 import static com.remondis.remap.basic.MapperTest.ZAHL_IN_A;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/basic/MapIterableTest.java
+++ b/src/test/java/com/remondis/remap/basic/MapIterableTest.java
@@ -20,11 +20,11 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapIterableTest {
+class MapIterableTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void mapFromIterable() {
+  void mapFromIterable() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .omitInSource(A::getMoreInA)

--- a/src/test/java/com/remondis/remap/basic/MapperTest.java
+++ b/src/test/java/com/remondis/remap/basic/MapperTest.java
@@ -1,9 +1,9 @@
 package com.remondis.remap.basic;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
@@ -30,7 +30,7 @@ public class MapperTest {
   public static final int NUMBER = 210;
   public static final String STRING = "a string";
 
-  @Test(expected = MappingException.class)
+  @Test
   public void shouldDenyMapNull() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
@@ -42,7 +42,7 @@ public class MapperTest {
             .to(BResource.class)
             .mapper())
         .mapper();
-    mapper.map((A) null);
+    assertThatThrownBy(() -> mapper.map((A) null)).isInstanceOf(MappingException.class);
   }
 
   @Test
@@ -184,44 +184,44 @@ public class MapperTest {
   /**
    * Ensures that the mapper does not allow an omitted field in the source to be reassigned.
    */
-  @Test(expected = MappingException.class)
+  @Test
   public void reassignAnOmmitedFieldInSource() {
-    Mapping.from(AReassign.class)
+    assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .omitInSource(AReassign::getFirstNumberInA)
         .reassign(AReassign::getFirstNumberInA)
         .to(AResourceReassign::getFirstNumberInAResource)
         .reassign(AReassign::getSecondNumberInA)
         .to(AResourceReassign::getSecondNumberInAResource)
-        .mapper();
+        .mapper()).isInstanceOf(MappingException.class);
   }
 
   /**
    * Ensures that the mapper does not allow an omitted field in the destination to be reassigned.
    */
-  @Test(expected = MappingException.class)
+  @Test
   public void reassignToAnOmmitedFieldInDestination() {
-    Mapping.from(AReassign.class)
+    assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .omitInDestination(ar -> ar.getFirstNumberInAResource())
         .reassign(AReassign::getFirstNumberInA)
         .to(AResourceReassign::getFirstNumberInAResource)
         .reassign(AReassign::getSecondNumberInA)
         .to(AResourceReassign::getSecondNumberInAResource)
-        .mapper();
+        .mapper()).isInstanceOf(MappingException.class);
   }
 
   /**
    * Ensures that the mapper detects an unmapped field in the destination while the all source fields are mapped.
    */
-  @Test(expected = MappingException.class)
+  @Test
   public void reassignAndOneDestinationFieldIsUnmapped() {
-    Mapping.from(AReassign.class)
+    assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .reassign(AReassign::getFirstNumberInA)
         .to(AResourceReassign::getSecondNumberInAResource)
         .omitInSource(AReassign::getSecondNumberInA)
-        .mapper();
+        .mapper()).isInstanceOf(MappingException.class);
   }
 
   @SuppressWarnings("rawtypes")

--- a/src/test/java/com/remondis/remap/basic/MapperTest.java
+++ b/src/test/java/com/remondis/remap/basic/MapperTest.java
@@ -19,7 +19,7 @@ import com.remondis.remap.MappingException;
 import com.remondis.remap.test.MapperTests.PersonWithAddress;
 import com.remondis.remap.test.MapperTests.PersonWithFoo;
 
-public class MapperTest {
+class MapperTest {
 
   public static final String MORE_IN_A = "moreInA";
   public static final Long ZAHL_IN_A = -88L;
@@ -31,7 +31,7 @@ public class MapperTest {
   public static final String STRING = "a string";
 
   @Test
-  public void shouldDenyMapNull() {
+  void shouldDenyMapNull() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .reassign(A::getMoreInA)
@@ -46,7 +46,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldFailDueToNoRegisteredMapper() {
+  void shouldFailDueToNoRegisteredMapper() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(AResource.class)
         .reassign(A::getMoreInA)
@@ -62,7 +62,7 @@ public class MapperTest {
    * check the inherited fields.
    */
   @Test
-  public void shouldMapCorrectly() {
+  void shouldMapCorrectly() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .omitInSource(A::getMoreInA)
@@ -104,7 +104,7 @@ public class MapperTest {
    * configuration. The {@link Mapper} is expected to throw a {@link MappingException}.
    */
   @Test
-  public void oneMoreSourceFieldInA() {
+  void oneMoreSourceFieldInA() {
     assertThatThrownBy(() -> Mapping.from(AWithOneMoreSourceField.class)
         .to(AResourceWithOneMoreSourceField.class)
         .mapper()).isInstanceOf(MappingException.class)
@@ -115,7 +115,7 @@ public class MapperTest {
    * Ensures that an unmatched source field is omitted.
    */
   @Test
-  public void oneMoreSourceFieldInAButItIsOmitted() {
+  void oneMoreSourceFieldInAButItIsOmitted() {
     Mapper<AWithOneMoreSourceField, AResourceWithOneMoreSourceField> mapper = Mapping
         .from(AWithOneMoreSourceField.class)
         .to(AResourceWithOneMoreSourceField.class)
@@ -135,7 +135,7 @@ public class MapperTest {
    * configuration. The {@link Mapper} is expected to throw a {@link MappingException}.
    */
   @Test
-  public void oneMoreDestinationFieldInAResource() {
+  void oneMoreDestinationFieldInAResource() {
     assertThatThrownBy(() -> Mapping.from(AWithOneMoreDestinationField.class)
         .to(AResourceWithOneMoreDestinationField.class)
         .mapper()).isInstanceOf(MappingException.class)
@@ -146,7 +146,7 @@ public class MapperTest {
    * Ensures that an unmatched destination field is omitted.
    */
   @Test
-  public void oneMoreDestinationFieldInAResourceButItsOmmited() {
+  void oneMoreDestinationFieldInAResourceButItsOmmited() {
     Mapper<AWithOneMoreDestinationField, AResourceWithOneMoreDestinationField> mapper = Mapping
         .from(AWithOneMoreDestinationField.class)
         .to(AResourceWithOneMoreDestinationField.class)
@@ -164,7 +164,7 @@ public class MapperTest {
    * Ensures that the mapper performs a correct reassigment of fields.
    */
   @Test
-  public void reassign() {
+  void reassign() {
     Mapper<AReassign, AResourceReassign> mapper = Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .reassign(AReassign::getFirstNumberInA)
@@ -185,7 +185,7 @@ public class MapperTest {
    * Ensures that the mapper does not allow an omitted field in the source to be reassigned.
    */
   @Test
-  public void reassignAnOmmitedFieldInSource() {
+  void reassignAnOmmitedFieldInSource() {
     assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .omitInSource(AReassign::getFirstNumberInA)
@@ -200,7 +200,7 @@ public class MapperTest {
    * Ensures that the mapper does not allow an omitted field in the destination to be reassigned.
    */
   @Test
-  public void reassignToAnOmmitedFieldInDestination() {
+  void reassignToAnOmmitedFieldInDestination() {
     assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .omitInDestination(ar -> ar.getFirstNumberInAResource())
@@ -215,7 +215,7 @@ public class MapperTest {
    * Ensures that the mapper detects an unmapped field in the destination while the all source fields are mapped.
    */
   @Test
-  public void reassignAndOneDestinationFieldIsUnmapped() {
+  void reassignAndOneDestinationFieldIsUnmapped() {
     assertThatThrownBy(() -> Mapping.from(AReassign.class)
         .to(AResourceReassign.class)
         .reassign(AReassign::getFirstNumberInA)
@@ -226,7 +226,7 @@ public class MapperTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void shouldMapToNewList() {
+  void shouldMapToNewList() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .omitInSource(A::getMoreInA)
@@ -279,7 +279,7 @@ public class MapperTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void shouldMapToNewSet() {
+  void shouldMapToNewSet() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .omitInSource(A::getMoreInA)
@@ -337,7 +337,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldDenyIllegalArguments() {
+  void shouldDenyIllegalArguments() {
 
     assertThatThrownBy(() -> {
       Mapping.from(null);

--- a/src/test/java/com/remondis/remap/builder/BuilderTest.java
+++ b/src/test/java/com/remondis/remap/builder/BuilderTest.java
@@ -10,13 +10,13 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class BuilderTest {
+class BuilderTest {
 
   private static final long IDENTIFIER = 4L;
   private static final String NAME = "Bob";
 
   @Test
-  public void shouldMapToDestinationFromBuilder() {
+  void shouldMapToDestinationFromBuilder() {
 
     Mapper<BuilderModel, DestinationModel> mapper = Mapping.from(BuilderModel.class)
         .to(DestinationModel.class)
@@ -35,7 +35,7 @@ public class BuilderTest {
   }
 
   @Test
-  public void failsWhenMapFromBuilder() {
+  void failsWhenMapFromBuilder() {
     assertThrows(MappingException.class, () -> Mapping.from(DestinationModel.class)
         .to(BuilderModel.class)
         .mapper());

--- a/src/test/java/com/remondis/remap/builder/BuilderTest.java
+++ b/src/test/java/com/remondis/remap/builder/BuilderTest.java
@@ -1,8 +1,9 @@
 package com.remondis.remap.builder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -33,10 +34,10 @@ public class BuilderTest {
         .ensure();
   }
 
-  @Test(expected = MappingException.class)
+  @Test
   public void failsWhenMapFromBuilder() {
-    Mapping.from(DestinationModel.class)
+    assertThrows(MappingException.class, () -> Mapping.from(DestinationModel.class)
         .to(BuilderModel.class)
-        .mapper();
+        .mapper());
   }
 }

--- a/src/test/java/com/remondis/remap/collections/CollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/CollectionsTest.java
@@ -1,10 +1,11 @@
 package com.remondis.remap.collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
@@ -19,11 +20,11 @@ public class CollectionsTest {
    * collection mapping while the mapper for the specified list elements was
    * missing.
    */
-  @Test(expected = MappingException.class)
+  @Test
   public void shouldCheckForRequiredMappers() {
-    Mapping.from(A.class)
+    assertThrows(MappingException.class, () -> Mapping.from(A.class)
         .to(AResource.class)
-        .mapper();
+        .mapper());
   }
 
   @Test

--- a/src/test/java/com/remondis/remap/collections/CollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/CollectionsTest.java
@@ -13,7 +13,7 @@ import com.remondis.remap.MappingException;
 import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
-public class CollectionsTest {
+class CollectionsTest {
 
   /**
    * There was a bug in collection mappings. It was possible to declare a
@@ -21,14 +21,14 @@ public class CollectionsTest {
    * missing.
    */
   @Test
-  public void shouldCheckForRequiredMappers() {
+  void shouldCheckForRequiredMappers() {
     assertThrows(MappingException.class, () -> Mapping.from(A.class)
         .to(AResource.class)
         .mapper());
   }
 
   @Test
-  public void shouldMapNestedCollections() {
+  void shouldMapNestedCollections() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
@@ -76,7 +76,7 @@ public class CollectionsTest {
   }
 
   @Test
-  public void shouldMapCollections() {
+  void shouldMapCollections() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/collections/NullInCollectionMappingTest.java
+++ b/src/test/java/com/remondis/remap/collections/NullInCollectionMappingTest.java
@@ -11,7 +11,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NullInCollectionMappingTest {
+class NullInCollectionMappingTest {
 
   static class Source {
     private List<String> stringList;
@@ -41,7 +41,7 @@ public class NullInCollectionMappingTest {
   }
 
   @Test
-  public void testMappingWithNullInCollection() {
+  void testMappingWithNullInCollection() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/collections/NullInCollectionMappingTest.java
+++ b/src/test/java/com/remondis/remap/collections/NullInCollectionMappingTest.java
@@ -3,13 +3,13 @@ package com.remondis.remap.collections;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NullInCollectionMappingTest {
 
@@ -51,6 +51,6 @@ public class NullInCollectionMappingTest {
     MappingException exception = assertThrows(MappingException.class, () -> mapper.map(source));
 
     String expectedMessage = "Cannot map null element in collection field 'stringList' from source type 'Source' to destination type 'Destination'.";
-    assertEquals("Unerwartete Exception-Nachricht", expectedMessage, exception.getMessage());
+    assertEquals(expectedMessage, exception.getMessage(), "Unerwartete Exception-Nachricht");
   }
 }

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
+++ b/src/test/java/com/remondis/remap/collections/fromSetToList/FromSetToListTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class FromSetToListTest {
+class FromSetToListTest {
 
   @Test
-  public void test() {
+  void test() {
     A a = new A();
     a.add(new A1("a1"));
     a.add(new A1("a2"));

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
+++ b/src/test/java/com/remondis/remap/collections/listAndMaps/ListAndMapsTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class ListAndMapsTest {
+class ListAndMapsTest {
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldMapNestedCollections() {
+  void shouldMapNestedCollections() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/collections/nestedCollections/NestedCollectionsTest.java
@@ -16,10 +16,10 @@ import com.remondis.remap.MappingException;
 import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
-public class NestedCollectionsTest {
+class NestedCollectionsTest {
 
   @Test
-  public void shouldDoMapperValidation() {
+  void shouldDoMapperValidation() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(AResource.class)
         .mapper()).isInstanceOf(MappingException.class)
@@ -30,7 +30,7 @@ public class NestedCollectionsTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldMapNestedCollections() {
+  void shouldMapNestedCollections() {
 
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
+++ b/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
@@ -1,16 +1,16 @@
 package com.remondis.remap.copyObjects;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-@Ignore
+@Disabled
 public class CopyObjectTest {
 
   private static final String EXPECTED_STRING = "string";

--- a/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
+++ b/src/test/java/com/remondis/remap/copyObjects/CopyObjectTest.java
@@ -11,12 +11,12 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
 @Disabled
-public class CopyObjectTest {
+class CopyObjectTest {
 
   private static final String EXPECTED_STRING = "string";
 
   @Test
-  public void shouldCopyObjectsOfSameType() {
+  void shouldCopyObjectsOfSameType() {
     B b = new B(EXPECTED_STRING);
     A a = new A(b);
 

--- a/src/test/java/com/remondis/remap/defaultMethods/DefaultMethodTest.java
+++ b/src/test/java/com/remondis/remap/defaultMethods/DefaultMethodTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.defaultMethods;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/defaultMethods/DefaultMethodTest.java
+++ b/src/test/java/com/remondis/remap/defaultMethods/DefaultMethodTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class DefaultMethodTest {
+class DefaultMethodTest {
   @Test
-  public void test_defaults_methods() {
+  void test_defaults_methods() {
     Mapper<Interface, DestinationBean> mapper = Mapping.from(Interface.class)
         .to(DestinationBean.class)
         .mapper();
@@ -20,7 +20,7 @@ public class DefaultMethodTest {
   }
 
   @Test
-  public void test_withOverridden_defaults_methods() {
+  void test_withOverridden_defaults_methods() {
     Mapper<Interface, DestinationBean> mapper = Mapping.from(Interface.class)
         .to(DestinationBean.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/demo/DemoTest.java
+++ b/src/test/java/com/remondis/remap/demo/DemoTest.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.demo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/demo/DemoTest.java
+++ b/src/test/java/com/remondis/remap/demo/DemoTest.java
@@ -6,9 +6,9 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class DemoTest {
+class DemoTest {
   @Test
-  public void demoMapping() {
+  void demoMapping() {
     Mapper<Customer, Person> customerPersonMapper = Mapping.from(Customer.class)
         .to(Person.class)
         // A customer has an address, a person might have no address

--- a/src/test/java/com/remondis/remap/demo/v2/MapPersonTest.java
+++ b/src/test/java/com/remondis/remap/demo/v2/MapPersonTest.java
@@ -1,11 +1,11 @@
 package com.remondis.remap.demo.v2;
 
 import static java.time.Period.between;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/demo/v2/MapPersonTest.java
+++ b/src/test/java/com/remondis/remap/demo/v2/MapPersonTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapPersonTest {
+class MapPersonTest {
 
   @Test
-  public void shouldMapToPersonView() {
+  void shouldMapToPersonView() {
     Person person = new Person("Mustermann", "Max", LocalDate.of(1988, 10, 9),
         new Address("Somewhere", "17a", "12346", "Nowhere", "max.mustermann@example.org"), "DE-71545498927");
 

--- a/src/test/java/com/remondis/remap/enums/EnumsTest.java
+++ b/src/test/java/com/remondis/remap/enums/EnumsTest.java
@@ -1,9 +1,9 @@
 package com.remondis.remap.enums;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/enums/EnumsTest.java
+++ b/src/test/java/com/remondis/remap/enums/EnumsTest.java
@@ -9,10 +9,10 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class EnumsTest {
+class EnumsTest {
 
   @Test
-  public void shouldMapEnums() {
+  void shouldMapEnums() {
     Mapper<Person, PersonResource> mapper = Mapping.from(Person.class)
         .to(PersonResource.class)
         .mapper();
@@ -29,7 +29,7 @@ public class EnumsTest {
   }
 
   @Test
-  public void shouldThrowMappingException() {
+  void shouldThrowMappingException() {
     assertThatThrownBy(() -> Mapping.from(Person.class)
         .to(AnotherResource.class)
         .mapper()).isInstanceOf(MappingException.class)

--- a/src/test/java/com/remondis/remap/flatCollectionMapping/DemoTest.java
+++ b/src/test/java/com/remondis/remap/flatCollectionMapping/DemoTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.flatCollectionMapping;
 
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/flatCollectionMapping/DemoTest.java
+++ b/src/test/java/com/remondis/remap/flatCollectionMapping/DemoTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class DemoTest {
+class DemoTest {
 
   @Test
-  public void replaceCollection() {
+  void replaceCollection() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .replaceCollection(Source::getIds, Destination::getIds)

--- a/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
+++ b/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
@@ -13,10 +13,10 @@ import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingConfiguration;
 import com.remondis.remap.MappingException;
 
-public class ChainedSetterTest {
+class ChainedSetterTest {
 
   @Test
-  public void testChainedSetter() {
+  void testChainedSetter() {
     Mapper<FluentSetterDto, FluentSetterDto> m = Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .allowFluentSetters()
@@ -31,7 +31,7 @@ public class ChainedSetterTest {
   }
 
   @Test
-  public void shouldComplainAboutEnabledFluentSetters() {
+  void shouldComplainAboutEnabledFluentSetters() {
     Mapper<FluentSetterDto, FluentSetterDto> mapper = Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .allowFluentSetters()
@@ -47,7 +47,7 @@ public class ChainedSetterTest {
   }
 
   @Test
-  public void shouldComplainAboutDisabledFluentSetters() {
+  void shouldComplainAboutDisabledFluentSetters() {
     Mapper<FluentSetterDto, FluentSetterDto> mapper = Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .omitOthers()
@@ -65,7 +65,7 @@ public class ChainedSetterTest {
   }
 
   @Test
-  public void shouldTestTheMapperWithoutErrors() {
+  void shouldTestTheMapperWithoutErrors() {
     Mapper<FluentSetterDto, FluentSetterDto> mapper = Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .omitOthers()
@@ -77,14 +77,14 @@ public class ChainedSetterTest {
   }
 
   @Test
-  public void shouldComplainAboutUnmappedProperties_dueToFluentSettersDisabled() {
+  void shouldComplainAboutUnmappedProperties_dueToFluentSettersDisabled() {
     assertThrows(MappingException.class, () -> Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .mapper());
   }
 
   @Test
-  public void shouldNotComplainAboutMissingMappings_ifFluentSettersEnabled() {
+  void shouldNotComplainAboutMissingMappings_ifFluentSettersEnabled() {
     Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
         .allowFluentSetters()
@@ -92,7 +92,7 @@ public class ChainedSetterTest {
   }
 
   @Test
-  public void fluentSettersShouldBeDisabledByDefault_backwardsCompatibility() {
+  void fluentSettersShouldBeDisabledByDefault_backwardsCompatibility() {
     MappingConfiguration<FluentSetterDto, FluentSetterDto> mappingConfiguration = Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class);
     assertFalse(mappingConfiguration.isFluentSettersAllowed());

--- a/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
+++ b/src/test/java/com/remondis/remap/fluent/ChainedSetterTest.java
@@ -1,10 +1,11 @@
 package com.remondis.remap.fluent;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -75,11 +76,11 @@ public class ChainedSetterTest {
         .ensure();
   }
 
-  @Test(expected = MappingException.class)
+  @Test
   public void shouldComplainAboutUnmappedProperties_dueToFluentSettersDisabled() {
-    Mapping.from(FluentSetterDto.class)
+    assertThrows(MappingException.class, () -> Mapping.from(FluentSetterDto.class)
         .to(FluentSetterDto.class)
-        .mapper();
+        .mapper());
   }
 
   @Test

--- a/src/test/java/com/remondis/remap/generics/GenericsTest.java
+++ b/src/test/java/com/remondis/remap/generics/GenericsTest.java
@@ -1,12 +1,12 @@
 package com.remondis.remap.generics;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/generics/GenericsTest.java
+++ b/src/test/java/com/remondis/remap/generics/GenericsTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class GenericsTest {
+class GenericsTest {
 
   @Test
-  public void shouldMapListOfGenericTypeFromInstance() {
+  void shouldMapListOfGenericTypeFromInstance() {
 
     List<Bean<String>> list = asList(new Bean<>("A"), new Bean<>("B"), new Bean<>("C"));
 
@@ -42,7 +42,7 @@ public class GenericsTest {
   }
 
   @Test
-  public void shouldMapGenericTypeFromInstance() {
+  void shouldMapGenericTypeFromInstance() {
     Mapper<Bean<String>, Bean2<String>> mapper = Mapping.from(new Bean<String>())
         .to(new Bean2<String>())
         .reassign(Bean::getObject)

--- a/src/test/java/com/remondis/remap/implicitMappings/customTypeConversions/CustomTypeConversionsTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/customTypeConversions/CustomTypeConversionsTest.java
@@ -2,13 +2,13 @@ package com.remondis.remap.implicitMappings.customTypeConversions;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/implicitMappings/customTypeConversions/CustomTypeConversionsTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/customTypeConversions/CustomTypeConversionsTest.java
@@ -19,10 +19,10 @@ import com.remondis.remap.TypeMapping;
  * A mapping of property B->B' is performed implicitly if the field names are equal and [ the type is equal OR a type
  * mapper was registered that maps type(b) -> type(b') ].
  */
-public class CustomTypeConversionsTest {
+class CustomTypeConversionsTest {
 
   @Test
-  public void errorHandling() {
+  void errorHandling() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(AResource.class)
         .mapper()).isInstanceOf(MappingException.class)
@@ -31,14 +31,14 @@ public class CustomTypeConversionsTest {
   }
 
   @Test
-  public void mappingImplicitNullValues() {
+  void mappingImplicitNullValues() {
     A a = new A(null);
     AResource aResource = mapper().map(a);
     assertNull(aResource.getAddresses());
   }
 
   @Test
-  public void mappingImplicit() {
+  void mappingImplicit() {
     List<CharSequence> charSeqs = asList((CharSequence) "Address 1", (CharSequence) "Address 2");
     A a = new A(charSeqs);
     AResource aResource = mapper().map(a);

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
@@ -1,14 +1,14 @@
 package com.remondis.remap.implicitMappings.differentFieldNames;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -22,7 +22,7 @@ public class ImplicitMappingTest {
 
   private Mapper<A, AResource> aMapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/differentFieldNames/ImplicitMappingTest.java
@@ -18,12 +18,12 @@ import com.remondis.remap.Mapping;
  * A mapping of property B->B' is performed implicitly if the field names are equal and [ the type is equal OR a type
  * mapper was registered that maps type(b) -> type(b') ].
  */
-public class ImplicitMappingTest {
+class ImplicitMappingTest {
 
   private Mapper<A, AResource> aMapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .reassign(B::getString)
@@ -40,7 +40,7 @@ public class ImplicitMappingTest {
   }
 
   @Test
-  public void testAssert() {
+  void testAssert() {
     AssertMapping.of(aMapper)
         .expectReassign(A::getB)
         .to(AResource::getbResource)
@@ -50,13 +50,13 @@ public class ImplicitMappingTest {
   }
 
   @Test
-  public void mappingImplicitNullValues() {
+  void mappingImplicitNullValues() {
     AResource aResource = aMapper.map(new A(null, null));
     assertNull(aResource.getbResource());
   }
 
   @Test
-  public void mappingImplicit() {
+  void mappingImplicit() {
     AResource aResource = aMapper
         .map(new A(new B("string"), asList(new B("string"), new B("string1"), new B("string2"))));
     assertNotNull(aResource.getbResource());

--- a/src/test/java/com/remondis/remap/implicitMappings/sameFieldAndType/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/sameFieldAndType/ImplicitMappingTest.java
@@ -1,13 +1,13 @@
 package com.remondis.remap.implicitMappings.sameFieldAndType;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
@@ -19,7 +19,7 @@ import com.remondis.remap.Mapping;
 public class ImplicitMappingTest {
   private Mapper<A, AResource> aMapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.aMapper = Mapping.from(A.class)
         .to(AResource.class)

--- a/src/test/java/com/remondis/remap/implicitMappings/sameFieldAndType/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/sameFieldAndType/ImplicitMappingTest.java
@@ -16,18 +16,18 @@ import com.remondis.remap.Mapping;
  * A mapping of property B->B' is performed implicitly if the field names are equal and [ the type is equal OR a type
  * mapper was registered that maps type(b) -> type(b') ].
  */
-public class ImplicitMappingTest {
+class ImplicitMappingTest {
   private Mapper<A, AResource> aMapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.aMapper = Mapping.from(A.class)
         .to(AResource.class)
         .mapper();
   }
 
   @Test
-  public void mappingImplicit() {
+  void mappingImplicit() {
     AResource aResource = aMapper
         .map(new A(new B("string"), asList(new B("string"), new B("string1"), new B("string2"))));
     assertNotNull(aResource.getB());

--- a/src/test/java/com/remondis/remap/implicitMappings/sameFieldNames/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/sameFieldNames/ImplicitMappingTest.java
@@ -1,14 +1,14 @@
 package com.remondis.remap.implicitMappings.sameFieldNames;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
@@ -20,7 +20,7 @@ import com.remondis.remap.Mapping;
 public class ImplicitMappingTest {
   private Mapper<A, AResource> aMapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)

--- a/src/test/java/com/remondis/remap/implicitMappings/sameFieldNames/ImplicitMappingTest.java
+++ b/src/test/java/com/remondis/remap/implicitMappings/sameFieldNames/ImplicitMappingTest.java
@@ -17,11 +17,11 @@ import com.remondis.remap.Mapping;
  * A mapping of property B->B' is performed implicitly if the field names are equal and [ the type is equal OR a type
  * mapper was registered that maps type(b) -> type(b') ].
  */
-public class ImplicitMappingTest {
+class ImplicitMappingTest {
   private Mapper<A, AResource> aMapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .reassign(B::getString)
@@ -34,13 +34,13 @@ public class ImplicitMappingTest {
   }
 
   @Test
-  public void mappingImplicitNullValues() {
+  void mappingImplicitNullValues() {
     AResource aResource = aMapper.map(new A(null, null));
     assertNull(aResource.getB());
   }
 
   @Test
-  public void mappingImplicit() {
+  void mappingImplicit() {
     AResource aResource = aMapper
         .map(new A(new B("string"), asList(new B("string"), new B("string1"), new B("string2"))));
     assertNotNull(aResource.getB());

--- a/src/test/java/com/remondis/remap/inheritance/MapperTest.java
+++ b/src/test/java/com/remondis/remap/inheritance/MapperTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.inheritance;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/inheritance/MapperTest.java
+++ b/src/test/java/com/remondis/remap/inheritance/MapperTest.java
@@ -10,7 +10,7 @@ import com.remondis.remap.MappingConfiguration;
 import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
-public class MapperTest {
+class MapperTest {
 
   public static final String MORE_IN_A = "moreInA";
   public static final Long ZAHL_IN_A = -88L;
@@ -25,7 +25,7 @@ public class MapperTest {
    * Ensures that the mapper maps inherited field correctly.
    */
   @Test
-  public void shouldMapInheritedFields() {
+  void shouldMapInheritedFields() {
     Mapper<Child, ChildResource> map = Mapping.from(Child.class)
         .to(ChildResource.class)
         .omitInSource(Child::getMoreInParent)
@@ -65,7 +65,7 @@ public class MapperTest {
    * Ensures that the mapper maps interface defined fields correctly.
    */
   @Test
-  public void shouldMapWithInterfaceDefinedMethods() {
+  void shouldMapWithInterfaceDefinedMethods() {
     Mapper<Child, ChildResource> map = Mapping.from(Child.class)
         .to(ChildResource.class)
         .reassign(ChildInterface::getString)
@@ -104,7 +104,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldReuseParentMapperConfig() {
+  void shouldReuseParentMapperConfig() {
     MappingConfiguration<? extends Parent, ? extends ParentResource> parentMapping = Mapping.from(Parent.class)
         .to(ParentResource.class);
     parentMappingConfig(parentMapping);

--- a/src/test/java/com/remondis/remap/interfaceMapping/EntityMappingTest.java
+++ b/src/test/java/com/remondis/remap/interfaceMapping/EntityMappingTest.java
@@ -1,10 +1,10 @@
 package com.remondis.remap.interfaceMapping;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -15,7 +15,7 @@ public class EntityMappingTest {
   private Mapper<EntityA, EntityADTO> entityMapperWithoutId;
   private Mapper<EntityA, EntityWithIdDTO> entityMapperWithId;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.entityMapperWithoutId = Mapping.from(EntityA.class)
         .to(EntityADTO.class)

--- a/src/test/java/com/remondis/remap/interfaceMapping/EntityMappingTest.java
+++ b/src/test/java/com/remondis/remap/interfaceMapping/EntityMappingTest.java
@@ -10,13 +10,13 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class EntityMappingTest {
+class EntityMappingTest {
 
   private Mapper<EntityA, EntityADTO> entityMapperWithoutId;
   private Mapper<EntityA, EntityWithIdDTO> entityMapperWithId;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.entityMapperWithoutId = Mapping.from(EntityA.class)
         .to(EntityADTO.class)
         .omitInSource(HasId::getId)
@@ -28,7 +28,7 @@ public class EntityMappingTest {
   }
 
   @Test
-  public void shouldMapEntityWithoutInterfaceAttribute() {
+  void shouldMapEntityWithoutInterfaceAttribute() {
     EntityA entity = new EntityA();
     entity.setName("Test Entity");
     EntityADTO dto = entityMapperWithoutId.map(entity);
@@ -37,7 +37,7 @@ public class EntityMappingTest {
   }
 
   @Test
-  public void shouldMapEntityWithInterfaceAttribute() {
+  void shouldMapEntityWithInterfaceAttribute() {
     EntityA entity = new EntityA();
     entity.setName("Test Entity");
     EntityWithIdDTO dto = entityMapperWithId.map(entity);
@@ -47,7 +47,7 @@ public class EntityMappingTest {
   }
 
   @Test
-  public void shouldComplainAboutImplicitMapping() {
+  void shouldComplainAboutImplicitMapping() {
     Mapper<EntityA, EntityADTO> implicitMapper = Mapping.from(EntityA.class)
         .to(EntityADTO.class)
         .omitInSource(EntityA::getId)

--- a/src/test/java/com/remondis/remap/interfaces/MapperTest.java
+++ b/src/test/java/com/remondis/remap/interfaces/MapperTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.interfaces;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/interfaces/MapperTest.java
+++ b/src/test/java/com/remondis/remap/interfaces/MapperTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   private static final String STRING = "aString";
 
   @Test
-  public void shouldSupportInterfaces() {
+  void shouldSupportInterfaces() {
     Mapper<Source, DestImpl> mapper = Mapping.from(Source.class)
         .to(DestImpl.class)
         .reassign(Source::getString)

--- a/src/test/java/com/remondis/remap/mapInto/MapperTest.java
+++ b/src/test/java/com/remondis/remap/mapInto/MapperTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/mapInto/MapperTest.java
+++ b/src/test/java/com/remondis/remap/mapInto/MapperTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   private static final Integer EXPECTED_AGE = 29;
   private static final String EXPECTED_LASTNAME = "Griffin";
@@ -19,7 +19,7 @@ public class MapperTest {
   private static final String EXPECTED_CITY = "Lünen";
 
   @Test
-  public void shouldUseDestinationObjectForNestedMappingsAlso() {
+  void shouldUseDestinationObjectForNestedMappingsAlso() {
     Address address1 = new Address(1, "street1", "city1");
     Address address2 = new Address(2, "street2", "city2");
     List<Address> addresses = Arrays.asList(address1, address2);

--- a/src/test/java/com/remondis/remap/maps/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/MapsTest.java
@@ -1,14 +1,14 @@
 package com.remondis.remap.maps;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/maps/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/MapsTest.java
@@ -16,10 +16,10 @@ import com.remondis.remap.TypeMapping;
 import com.remondis.remap.basic.B;
 import com.remondis.remap.basic.BResource;
 
-public class MapsTest {
+class MapsTest {
 
   @Test
-  public void shouldMapMapsUsingMappers() {
+  void shouldMapMapsUsingMappers() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .mapper();
@@ -55,7 +55,7 @@ public class MapsTest {
   }
 
   @Test
-  public void shouldWorkaroundMappingOfMaps() {
+  void shouldWorkaroundMappingOfMaps() {
     Mapper<B, BResource> bMapper = Mapping.from(B.class)
         .to(BResource.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.maps.incompatibleListMapTypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;

--- a/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/incompatibleListMapTypeValidation/TypeValidationTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class TypeValidationTest {
+class TypeValidationTest {
 
   @Test
-  public void shouldDetectIncompatibleCollections() {
+  void shouldDetectIncompatibleCollections() {
     assertThatThrownBy(() -> {
       Mapping.from(A.class)
           .to(AMapped.class)

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.maps.listMapTypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
+++ b/src/test/java/com/remondis/remap/maps/listMapTypeValidation/TypeValidationTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class TypeValidationTest {
+class TypeValidationTest {
 
   @Test
-  public void shouldDetectBothNestedGenericTypes() {
+  void shouldDetectBothNestedGenericTypes() {
     Mapper<B, BMapped> bMapper = Mapping.from(B.class)
         .to(BMapped.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
@@ -8,7 +8,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
+++ b/src/test/java/com/remondis/remap/maps/nested/MapsTest.java
@@ -14,10 +14,10 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class MapsTest {
+class MapsTest {
 
   @Test
-  public void shouldDoMapperValidation() {
+  void shouldDoMapperValidation() {
     Mapper<A1, A1Mapped> a1Mapper = Mapping.from(A1.class)
         .to(A1Mapped.class)
         .mapper();
@@ -56,7 +56,7 @@ public class MapsTest {
   }
 
   @Test
-  public void shouldMapNestedKeyValues() {
+  void shouldMapNestedKeyValues() {
     A1 a1 = new A1("key1");
     A2 key1 = new A2("value-key1");
     A3 value1 = new A3("value-value1");

--- a/src/test/java/com/remondis/remap/maps/reassign/ReassignTest.java
+++ b/src/test/java/com/remondis/remap/maps/reassign/ReassignTest.java
@@ -1,10 +1,10 @@
 package com.remondis.remap.maps.reassign;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/maps/reassign/ReassignTest.java
+++ b/src/test/java/com/remondis/remap/maps/reassign/ReassignTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class ReassignTest {
+class ReassignTest {
 
   @Test
-  public void shouldReassignMaps() {
+  void shouldReassignMaps() {
     Mapper<A, AMapped> mapper = Mapping.from(A.class)
         .to(AMapped.class)
         .reassign(A::getBmap)

--- a/src/test/java/com/remondis/remap/multimapping/reassign/MapperTest.java
+++ b/src/test/java/com/remondis/remap/multimapping/reassign/MapperTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.multimapping.reassign;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/multimapping/reassign/MapperTest.java
+++ b/src/test/java/com/remondis/remap/multimapping/reassign/MapperTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldAllowMultipleReassigns() {
+  void shouldAllowMultipleReassigns() {
 
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)

--- a/src/test/java/com/remondis/remap/multimapping/replace/MapperTest.java
+++ b/src/test/java/com/remondis/remap/multimapping/replace/MapperTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.multimapping.replace;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/multimapping/replace/MapperTest.java
+++ b/src/test/java/com/remondis/remap/multimapping/replace/MapperTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   private static final int EXPECTED_INT = Integer.MIN_VALUE;
   private static final int EXPECTED_NUMBER = Integer.MAX_VALUE;
@@ -15,7 +15,7 @@ public class MapperTest {
   private static final String EXPECTED_A_STRING = "aString";
 
   @Test
-  public void shouldAllowMultiMappings() {
+  void shouldAllowMultiMappings() {
 
     B b = new B(EXPECTED_STRING, EXPECTED_NUMBER, EXPECTED_INT);
     A a = new A(EXPECTED_A_STRING, b);

--- a/src/test/java/com/remondis/remap/noImplicitMappings/NoImplicitMappingsTest.java
+++ b/src/test/java/com/remondis/remap/noImplicitMappings/NoImplicitMappingsTest.java
@@ -2,14 +2,14 @@ package com.remondis.remap.noImplicitMappings;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -19,7 +19,7 @@ public class NoImplicitMappingsTest {
 
   private Mapper<B, B> bMapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.bMapper = Mapping.from(B.class)
         .to(B.class)

--- a/src/test/java/com/remondis/remap/noImplicitMappings/NoImplicitMappingsTest.java
+++ b/src/test/java/com/remondis/remap/noImplicitMappings/NoImplicitMappingsTest.java
@@ -15,12 +15,12 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class NoImplicitMappingsTest {
+class NoImplicitMappingsTest {
 
   private Mapper<B, B> bMapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.bMapper = Mapping.from(B.class)
         .to(B.class)
         .mapper();
@@ -44,7 +44,7 @@ public class NoImplicitMappingsTest {
   }
 
   @Test
-  public void shouldMapRight() {
+  void shouldMapRight() {
     int expectedBInt = 42;
     String expectedBString = "string";
     B b = new B(expectedBString, expectedBInt);
@@ -61,7 +61,7 @@ public class NoImplicitMappingsTest {
   }
 
   @Test
-  public void shouldAssertHappyPath() {
+  void shouldAssertHappyPath() {
     AssertMapping.of(getAMapper())
         .expectNoImplicitMappings()
         .expectReassign(A::getBs)
@@ -76,7 +76,7 @@ public class NoImplicitMappingsTest {
   }
 
   @Test
-  public void shouldComplainAboutDifferentImplicitMappingStrategy_expectImplicit() {
+  void shouldComplainAboutDifferentImplicitMappingStrategy_expectImplicit() {
     assertThatThrownBy(() -> AssertMapping.of(getAMapper())
         .expectReassign(A::getBs)
         .to(A::getBs)
@@ -91,7 +91,7 @@ public class NoImplicitMappingsTest {
   }
 
   @Test
-  public void shouldComplainAboutDifferentImplicitMappingStrategy_expectNoImplicit() {
+  void shouldComplainAboutDifferentImplicitMappingStrategy_expectNoImplicit() {
     Mapper<A, A> implicitMapper = Mapping.from(A.class)
         .to(A.class)
         .useMapper(bMapper)

--- a/src/test/java/com/remondis/remap/nullvalues/MapperTest.java
+++ b/src/test/java/com/remondis/remap/nullvalues/MapperTest.java
@@ -1,12 +1,12 @@
 package com.remondis.remap.nullvalues;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/nullvalues/MapperTest.java
+++ b/src/test/java/com/remondis/remap/nullvalues/MapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   private static final Long ZAHL_IN_A = -88L;
   private static final Integer B_INTEGER = -999;
@@ -22,7 +22,7 @@ public class MapperTest {
   private static final String STRING = "a string";
 
   @Test
-  public void shouldSkipReplaceNullValues() {
+  void shouldSkipReplaceNullValues() {
     AtomicBoolean called = new AtomicBoolean(false);
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
@@ -73,7 +73,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldNotSkipReplaceNullValues() {
+  void shouldNotSkipReplaceNullValues() {
     AtomicBoolean called = new AtomicBoolean(false);
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
@@ -124,7 +124,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldReassignNullValue() {
+  void shouldReassignNullValue() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .reassign(A::getMoreInA)

--- a/src/test/java/com/remondis/remap/omitOthers/MapperTest.java
+++ b/src/test/java/com/remondis/remap/omitOthers/MapperTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.omitOthers;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/omitOthers/MapperTest.java
+++ b/src/test/java/com/remondis/remap/omitOthers/MapperTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldOmitOtherSourceProperties() {
+  void shouldOmitOtherSourceProperties() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -25,7 +25,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldOmitOtherDestinationProperties() {
+  void shouldOmitOtherDestinationProperties() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -38,7 +38,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldOmitOtherSourceAndDestFields_withExpectOtherSourceAndDestFieldsToBeOmitted() {
+  void shouldOmitOtherSourceAndDestFields_withExpectOtherSourceAndDestFieldsToBeOmitted() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -60,7 +60,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldOmitOtherSourceAndDestFields_withExpectOthersToBeOmitted() {
+  void shouldOmitOtherSourceAndDestFields_withExpectOthersToBeOmitted() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -81,7 +81,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldOmitOthers_withExpectOthersToBeOmitted() {
+  void shouldOmitOthers_withExpectOthersToBeOmitted() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -101,7 +101,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldOmitOthers() {
+  void shouldOmitOthers() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)
@@ -125,7 +125,7 @@ public class MapperTest {
   }
 
   @Test
-  public void shouldDenyOmitOthersIfNotExpected() {
+  void shouldDenyOmitOthersIfNotExpected() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getId, AResource::getId)

--- a/src/test/java/com/remondis/remap/propertypathmapping/PropertyPathTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/PropertyPathTest.java
@@ -1,11 +1,11 @@
 package com.remondis.remap.propertypathmapping;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -15,7 +15,7 @@ public class PropertyPathTest {
 
   private Mapper<Person, PersonView> mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)

--- a/src/test/java/com/remondis/remap/propertypathmapping/PropertyPathTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/PropertyPathTest.java
@@ -11,12 +11,12 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class PropertyPathTest {
+class PropertyPathTest {
 
   private Mapper<Person, PersonView> mapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)
         .replace(Person::getAddress, PersonView::getStreet)
@@ -31,7 +31,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNull_1() {
+  void shouldNotComplainAboutNull_1() {
     Person person = new Person("forename", "name", null);
     PersonView view = mapper.map(person);
     assertEquals(person.getForename(), view.getForename());
@@ -40,7 +40,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNull_2() {
+  void shouldNotComplainAboutNull_2() {
     Person person = new Person("forename", "name", new Address(null, "houseNumber", "zipCode", "city"));
     PersonView view = mapper.map(person);
     assertEquals(person.getForename(), view.getForename());
@@ -56,7 +56,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldEvaluatePropertyPath() {
+  void shouldEvaluatePropertyPath() {
 
     Person person = new Person("forename", "name", new Address("street", "houseNumber", "zipCode", "city"));
 
@@ -75,7 +75,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldAssertCorrectly() {
+  void shouldAssertCorrectly() {
     AssertMapping.of(mapper)
         .expectReplace(Person::getAddress, PersonView::getStreet)
         .withPropertyPath(Address::getStreet)
@@ -89,7 +89,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
+  void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(Person::getAddress, PersonView::getStreet)
@@ -105,7 +105,7 @@ public class PropertyPathTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andTest() {
+  void shouldDistinctBetweenOtherReplaceOperations_andTest() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(Person::getAddress, PersonView::getStreet)

--- a/src/test/java/com/remondis/remap/propertypathmapping/collections/PropertyPathCollectionTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/collections/PropertyPathCollectionTest.java
@@ -2,13 +2,13 @@ package com.remondis.remap.propertypathmapping.collections;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -20,7 +20,7 @@ public class PropertyPathCollectionTest {
 
   private Mapper<CollectionSource, CollectionDestination> mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.mapper = Mapping.from(CollectionSource.class)
         .to(CollectionDestination.class)

--- a/src/test/java/com/remondis/remap/propertypathmapping/collections/PropertyPathCollectionTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/collections/PropertyPathCollectionTest.java
@@ -16,12 +16,12 @@ import com.remondis.remap.Mapping;
 import com.remondis.remap.propertypathmapping.Address;
 import com.remondis.remap.propertypathmapping.Person;
 
-public class PropertyPathCollectionTest {
+class PropertyPathCollectionTest {
 
   private Mapper<CollectionSource, CollectionDestination> mapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.mapper = Mapping.from(CollectionSource.class)
         .to(CollectionDestination.class)
         .replaceCollection(CollectionSource::getPersons, CollectionDestination::getCities)
@@ -31,7 +31,7 @@ public class PropertyPathCollectionTest {
   }
 
   @Test
-  public void shouldAssertCorrectly() {
+  void shouldAssertCorrectly() {
     AssertMapping.of(mapper)
         .expectReplaceCollection(CollectionSource::getPersons, CollectionDestination::getCities)
         .withPropertyPath(p -> p.getAddress()
@@ -40,7 +40,7 @@ public class PropertyPathCollectionTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNullValue() {
+  void shouldNotComplainAboutNullValue() {
     String expected1 = "city1";
     String expected2 = "city3";
     Person p1 = new Person("forename1", "name1", new Address("street1", "houseNumber1", "zipCode1", expected1));
@@ -59,7 +59,7 @@ public class PropertyPathCollectionTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNullItems() {
+  void shouldNotComplainAboutNullItems() {
     String expected1 = "city1";
     String expected2 = "city3";
     Person p1 = new Person("forename1", "name1", new Address("street1", "houseNumber1", "zipCode1", expected1));
@@ -77,7 +77,7 @@ public class PropertyPathCollectionTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
+  void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplaceCollection(CollectionSource::getPersons, CollectionDestination::getCities)
@@ -87,7 +87,7 @@ public class PropertyPathCollectionTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andTest() {
+  void shouldDistinctBetweenOtherReplaceOperations_andTest() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplaceCollection(CollectionSource::getPersons, CollectionDestination::getCities)

--- a/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/PropertyPathWithTransformationTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/PropertyPathWithTransformationTest.java
@@ -1,11 +1,11 @@
 package com.remondis.remap.propertypathmapping.withtransformation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -17,7 +17,7 @@ public class PropertyPathWithTransformationTest {
 
   private Mapper<Person, PersonView> mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)

--- a/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/PropertyPathWithTransformationTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/PropertyPathWithTransformationTest.java
@@ -13,12 +13,12 @@ import com.remondis.remap.Mapping;
 import com.remondis.remap.propertypathmapping.Address;
 import com.remondis.remap.propertypathmapping.Person;
 
-public class PropertyPathWithTransformationTest {
+class PropertyPathWithTransformationTest {
 
   private Mapper<Person, PersonView> mapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)
         .replace(Person::getAddress, PersonView::getStreetLength)
@@ -32,7 +32,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNull_1() {
+  void shouldNotComplainAboutNull_1() {
     Person person = new Person("forename", "name", null);
     PersonView view = mapper.map(person);
     assertNull(view.getStreetLengthWrap());
@@ -40,7 +40,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNull_2() {
+  void shouldNotComplainAboutNull_2() {
     Person person = new Person("forename", "name", new Address(null, "houseNumber", "zipCode", "city"));
     PersonView view = mapper.map(person);
     assertNull(view.getStreetLengthWrap());
@@ -48,7 +48,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldEvaluatePropertyPath() {
+  void shouldEvaluatePropertyPath() {
 
     String expectedStreet = "street";
     Person person = new Person("forename", "name", new Address(expectedStreet, "houseNumber", "zipCode", "city"));
@@ -60,7 +60,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldAssertCorrectly() {
+  void shouldAssertCorrectly() {
     AssertMapping.of(mapper)
         .expectReplace(Person::getAddress, PersonView::getStreetLength)
         .withPropertyPathAndTransformation(address -> address.getStreet())
@@ -71,7 +71,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldComplainAboutWrongPropertyPathCorrectly() {
+  void shouldComplainAboutWrongPropertyPathCorrectly() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(Person::getAddress, PersonView::getStreetLength)
@@ -84,7 +84,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
+  void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(Person::getAddress, PersonView::getStreetLength)
@@ -97,7 +97,7 @@ public class PropertyPathWithTransformationTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andTest() {
+  void shouldDistinctBetweenOtherReplaceOperations_andTest() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplace(Person::getAddress, PersonView::getStreetLength)

--- a/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/collections/PropertyPathWithTransformationCollectionTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/collections/PropertyPathWithTransformationCollectionTest.java
@@ -3,12 +3,12 @@ package com.remondis.remap.propertypathmapping.withtransformation.collections;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
@@ -19,7 +19,7 @@ public class PropertyPathWithTransformationCollectionTest {
 
   private Mapper<Person, PersonView> mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)

--- a/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/collections/PropertyPathWithTransformationCollectionTest.java
+++ b/src/test/java/com/remondis/remap/propertypathmapping/withtransformation/collections/PropertyPathWithTransformationCollectionTest.java
@@ -15,12 +15,12 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.propertypathmapping.Address;
 
-public class PropertyPathWithTransformationCollectionTest {
+class PropertyPathWithTransformationCollectionTest {
 
   private Mapper<Person, PersonView> mapper;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.mapper = Mapping.from(Person.class)
         .to(PersonView.class)
         .replaceCollection(Person::getAddresses, PersonView::getStreetLength)
@@ -30,14 +30,14 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldNotComplainAboutNull_1() {
+  void shouldNotComplainAboutNull_1() {
     Person person = new Person();
     PersonView view = mapper.map(person);
     assertNull(view.getStreetLength());
   }
 
   @Test
-  public void shouldNotComplainAboutNull_2() {
+  void shouldNotComplainAboutNull_2() {
     Person person = new Person(asList(new Address(null, "houseNumber", "zipCode", "city")));
     PersonView view = mapper.map(person);
     assertNotNull(view.getStreetLength());
@@ -46,7 +46,7 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldEvaluatePropertyPath() {
+  void shouldEvaluatePropertyPath() {
 
     String expectedStreet1 = "1";
     String expectedStreet2 = "2";
@@ -61,7 +61,7 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldAssertCorrectly() {
+  void shouldAssertCorrectly() {
     AssertMapping.of(mapper)
         .expectReplaceCollection(Person::getAddresses, PersonView::getStreetLength)
         .withPropertyPathAndTransformation(add -> add.getStreet())
@@ -69,7 +69,7 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldComplainAboutWrongPropertyPathCorrectly() {
+  void shouldComplainAboutWrongPropertyPathCorrectly() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplaceCollection(Person::getAddresses, PersonView::getStreetLength)
@@ -79,7 +79,7 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
+  void shouldDistinctBetweenOtherReplaceOperations_andSkipWhenNull() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplaceCollection(Person::getAddresses, PersonView::getStreetLength)
@@ -89,7 +89,7 @@ public class PropertyPathWithTransformationCollectionTest {
   }
 
   @Test
-  public void shouldDistinctBetweenOtherReplaceOperations_andTest() {
+  void shouldDistinctBetweenOtherReplaceOperations_andTest() {
     assertThatThrownBy(() -> {
       AssertMapping.of(mapper)
           .expectReplaceCollection(Person::getAddresses, PersonView::getStreetLength)

--- a/src/test/java/com/remondis/remap/regression/booleanObjectBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/booleanObjectBug/MapperTest.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.regression.booleanObjectBug;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 

--- a/src/test/java/com/remondis/remap/regression/booleanObjectBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/booleanObjectBug/MapperTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldMap() {
+  void shouldMap() {
     Mapping.from(A.class)
         .to(B.class)
         .reassign(A::getMail)

--- a/src/test/java/com/remondis/remap/regression/capitalLetterBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/capitalLetterBug/MapperTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.regression.capitalLetterBug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/regression/capitalLetterBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/capitalLetterBug/MapperTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   private static final String STRING = "aString";
 
   @Test
-  public void shouldMapProperties() {
+  void shouldMapProperties() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .reassign(A::getAString)

--- a/src/test/java/com/remondis/remap/regression/implicitPrimitiveToWrapperMappingBug/MappingTest.java
+++ b/src/test/java/com/remondis/remap/regression/implicitPrimitiveToWrapperMappingBug/MappingTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.regression.implicitPrimitiveToWrapperMappingBug;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/regression/implicitPrimitiveToWrapperMappingBug/MappingTest.java
+++ b/src/test/java/com/remondis/remap/regression/implicitPrimitiveToWrapperMappingBug/MappingTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MappingTest {
+class MappingTest {
 
   @Test
-  public void integer_implicitMappingFromPrimitiveToWrapper() {
+  void integer_implicitMappingFromPrimitiveToWrapper() {
     Mapper<IntPrimitive, IntWrapper> mapper = Mapping.from(IntPrimitive.class)
         .to(IntWrapper.class)
         .mapper();
@@ -26,7 +26,7 @@ public class MappingTest {
   }
 
   @Test
-  public void integer_MappingWrapperToPrimitive() {
+  void integer_MappingWrapperToPrimitive() {
     Mapper<IntWrapper, IntPrimitive> mapper = Mapping.from(IntWrapper.class)
         .to(IntPrimitive.class)
         .mapper();
@@ -41,7 +41,7 @@ public class MappingTest {
   }
 
   @Test
-  public void boolean_implicitMappingFromPrimitiveToWrapper() {
+  void boolean_implicitMappingFromPrimitiveToWrapper() {
     Mapper<BoolPrimitive, BoolWrapper> mapper = Mapping.from(BoolPrimitive.class)
         .to(BoolWrapper.class)
         .mapper();
@@ -56,7 +56,7 @@ public class MappingTest {
   }
 
   @Test
-  public void boolean_implicitMappingWrapperToPrimitive() {
+  void boolean_implicitMappingWrapperToPrimitive() {
     Mapper<BoolWrapper, BoolPrimitive> mapper = Mapping.from(BoolWrapper.class)
         .to(BoolPrimitive.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/regression/methodCallsInConstructor/MethodCallsInConstructorTest.java
+++ b/src/test/java/com/remondis/remap/regression/methodCallsInConstructor/MethodCallsInConstructorTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.regression.methodCallsInConstructor;
 
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/regression/methodCallsInConstructor/MethodCallsInConstructorTest.java
+++ b/src/test/java/com/remondis/remap/regression/methodCallsInConstructor/MethodCallsInConstructorTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MethodCallsInConstructorTest {
+class MethodCallsInConstructorTest {
 
   @Test
-  public void shouldNotComplainAboutInternalMethodsInConstructor() {
+  void shouldNotComplainAboutInternalMethodsInConstructor() {
     Mapper<A, A> mapper = Mapping.from(A.class)
         .to(A.class)
         .replace(A::getaString, A::getaString)

--- a/src/test/java/com/remondis/remap/regression/noBeanCopyBug/NoBeanCopyBug.java
+++ b/src/test/java/com/remondis/remap/regression/noBeanCopyBug/NoBeanCopyBug.java
@@ -1,10 +1,10 @@
 package com.remondis.remap.regression.noBeanCopyBug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/regression/noBeanCopyBug/NoBeanCopyBug.java
+++ b/src/test/java/com/remondis/remap/regression/noBeanCopyBug/NoBeanCopyBug.java
@@ -9,14 +9,14 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class NoBeanCopyBug {
+class NoBeanCopyBug {
 
   /**
    * There was a bug in mapping an object holding a {@link BigDecimal}, a Java object not complying to Java bean
    * convention. The attempt was made to copy this instance by calling a default constructor, but there is none.
    */
   @Test
-  public void noBeanCopyBug() {
+  void noBeanCopyBug() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/regression/npeDenyAlreadyOmitted/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/npeDenyAlreadyOmitted/MapperTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.regression.npeDenyAlreadyOmitted;
 
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 

--- a/src/test/java/com/remondis/remap/regression/npeDenyAlreadyOmitted/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/npeDenyAlreadyOmitted/MapperTest.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldMap() {
+  void shouldMap() {
     Mapping.from(A.class)
         .to(AResource.class)
         .omitInDestination(AResource::getOmitted)

--- a/src/test/java/com/remondis/remap/regression/npeOnUnmappedReadOnlyProperty/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/npeOnUnmappedReadOnlyProperty/MapperTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.regression.npeOnUnmappedReadOnlyProperty;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 

--- a/src/test/java/com/remondis/remap/regression/npeOnUnmappedReadOnlyProperty/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/npeOnUnmappedReadOnlyProperty/MapperTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
   @Test
-  public void test() {
+  void test() {
     assertThatThrownBy(() -> {
       Mapping.from(A.class)
           .to(B.class)

--- a/src/test/java/com/remondis/remap/regression/omitCustomGet/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitCustomGet/MapperTest.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.regression.omitCustomGet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/regression/omitCustomGet/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitCustomGet/MapperTest.java
@@ -6,10 +6,10 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void map() {
+  void map() {
     Mapper<Foo, FooMapped> mapper = Mapping.from(Foo.class)
         .to(FooMapped.class)
         .omitInSource(Foo::getFilteredBars)

--- a/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.regression.omitOthersOmitsImplicitMappings;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitOthersOmitsImplicitMappings/MapperTest.java
@@ -6,14 +6,14 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
 
   /**
    * The bug was, that omitOtherSourceProperties() removed all implicit mappings. In this case the Mapper complained
    * about field "string1" is not being mapped.
    */
   @Test
-  public void shouldNotBreakImplicitMappings() {
+  void shouldNotBreakImplicitMappings() {
     Mapper<A, B> mapper = Mapping.from(A.class)
         .to(B.class)
         .replace(A::getString2, B::getString2Length)

--- a/src/test/java/com/remondis/remap/regression/omitReadOnlyGetterBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitReadOnlyGetterBug/MapperTest.java
@@ -1,6 +1,6 @@
 package com.remondis.remap.regression.omitReadOnlyGetterBug;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 

--- a/src/test/java/com/remondis/remap/regression/omitReadOnlyGetterBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/omitReadOnlyGetterBug/MapperTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapping;
 
-public class MapperTest {
+class MapperTest {
   @Test
-  public void test() {
+  void test() {
 
     Mapping.from(A.class)
         .to(B.class)

--- a/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/readOnlyInterfacePropertyBug/MapperTest.java
@@ -12,10 +12,10 @@ import com.remondis.remap.Mapping;
  * implements an interface that declares a getter without a corresponding setter, the mapper reported this
  * read-only property as a missing mapping although read-only properties are no mapping targets.
  */
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldCreateMapperIfTargetImplementsInterfaceWithReadOnlyProperty() {
+  void shouldCreateMapperIfTargetImplementsInterfaceWithReadOnlyProperty() {
     Mapper<C, A> mapper = Mapping.from(C.class)
         .to(A.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/regression/replaceOnCollectionBug/ReplaceOnCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/regression/replaceOnCollectionBug/ReplaceOnCollectionsTest.java
@@ -1,13 +1,13 @@
 
 package com.remondis.remap.regression.replaceOnCollectionBug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/regression/replaceOnCollectionBug/ReplaceOnCollectionsTest.java
+++ b/src/test/java/com/remondis/remap/regression/replaceOnCollectionBug/ReplaceOnCollectionsTest.java
@@ -13,13 +13,13 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class ReplaceOnCollectionsTest {
+class ReplaceOnCollectionsTest {
 
   private static final String FLAT_MODIFIER = "_";
   private static final String MODIFIER = "_modified";
 
   @Test
-  public void test() {
+  void test() {
     Mapper<A, AResource> mapper = Mapping.from(A.class)
         .to(AResource.class)
         .replace(A::getStrings, AResource::getStrings)
@@ -51,7 +51,7 @@ public class ReplaceOnCollectionsTest {
   }
 
   @Test
-  public void test_map_list_to_strings() {
+  void test_map_list_to_strings() {
     Mapper<A, AFlat> mapper = Mapping.from(A.class)
         .to(AFlat.class)
         .replace(A::getStrings, AFlat::getString)

--- a/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/staleTrackedPropertiesBug/MapperTest.java
@@ -14,10 +14,10 @@ import com.remondis.remap.Mapping;
  * evaluation on the same thread then saw the stale property in addition to its own and failed with a "multiple
  * interactions" error.
  */
-public class MapperTest {
+class MapperTest {
 
   @Test
-  public void shouldNotTrackPropertiesOfFailedSelectorInvocation() {
+  void shouldNotTrackPropertiesOfFailedSelectorInvocation() {
     assertThatThrownBy(() -> Mapping.from(A.class)
         .to(B.class)
         .omitInSource(a -> {

--- a/src/test/java/com/remondis/remap/regression/typeMappingForCollectionsBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/typeMappingForCollectionsBug/MapperTest.java
@@ -1,14 +1,14 @@
 package com.remondis.remap.regression.typeMappingForCollectionsBug;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/regression/typeMappingForCollectionsBug/MapperTest.java
+++ b/src/test/java/com/remondis/remap/regression/typeMappingForCollectionsBug/MapperTest.java
@@ -14,7 +14,7 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.TypeMapping;
 
-public class MapperTest {
+class MapperTest {
 
   @Test
   @SuppressWarnings("unchecked")
@@ -37,7 +37,7 @@ public class MapperTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldUseReplaceCollectionInsteadOfTypeMapping() {
+  void shouldUseReplaceCollectionInsteadOfTypeMapping() {
     Mapper<A, B> mapper = Mapping.from(A.class)
         .to(B.class)
         .useMapper(TypeMapping.from(List.class)
@@ -56,7 +56,7 @@ public class MapperTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldUseReplaceInsteadOfTypeMapping() {
+  void shouldUseReplaceInsteadOfTypeMapping() {
     final Set<String> expected = new HashSet<>();
     expected.add("Z");
 

--- a/src/test/java/com/remondis/remap/regression/useMapperTwice/UseMapperTwiceTest.java
+++ b/src/test/java/com/remondis/remap/regression/useMapperTwice/UseMapperTwiceTest.java
@@ -2,7 +2,7 @@ package com.remondis.remap.regression.useMapperTwice;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/regression/useMapperTwice/UseMapperTwiceTest.java
+++ b/src/test/java/com/remondis/remap/regression/useMapperTwice/UseMapperTwiceTest.java
@@ -8,10 +8,10 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingException;
 
-public class UseMapperTwiceTest {
+class UseMapperTwiceTest {
 
   @Test
-  public void should_complain_with_types_of_mapper_when_useMapperTwice() {
+  void should_complain_with_types_of_mapper_when_useMapperTwice() {
     Mapper<B, BMapped> bMapper = Mapping.from(B.class)
         .to(BMapped.class)
         .replace(B::getString, BMapped::getStringLength)

--- a/src/test/java/com/remondis/remap/restructure/RestructureTest.java
+++ b/src/test/java/com/remondis/remap/restructure/RestructureTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.restructure;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/restructure/RestructureTest.java
+++ b/src/test/java/com/remondis/remap/restructure/RestructureTest.java
@@ -28,10 +28,10 @@ import com.remondis.resample.Samples;
  * </ul>
  * </p>
  */
-public class RestructureTest {
+class RestructureTest {
 
   @Test
-  public void shouldRestructure_implicit_mapping_operations() {
+  void shouldRestructure_implicit_mapping_operations() {
     Mapper<Bean, RestructuredBean> mapper = Mapping.from(Bean.class)
         .to(RestructuredBean.class)
         .omitOtherSourceProperties()
@@ -52,7 +52,7 @@ public class RestructureTest {
   }
 
   @Test
-  public void shouldRestructure_explicit_mapping_operations() {
+  void shouldRestructure_explicit_mapping_operations() {
 
     Mapper<Bean, RestructuredBean> mapper = Mapping.from(Bean.class)
         .to(RestructuredBean.class)

--- a/src/test/java/com/remondis/remap/restructure/demo/RestructuringDemoTest.java
+++ b/src/test/java/com/remondis/remap/restructure/demo/RestructuringDemoTest.java
@@ -4,7 +4,7 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.resample.Samples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestructuringDemoTest {
 

--- a/src/test/java/com/remondis/remap/restructure/demo/RestructuringDemoTest.java
+++ b/src/test/java/com/remondis/remap/restructure/demo/RestructuringDemoTest.java
@@ -6,10 +6,10 @@ import com.remondis.remap.Mapping;
 import com.remondis.resample.Samples;
 import org.junit.jupiter.api.Test;
 
-public class RestructuringDemoTest {
+class RestructuringDemoTest {
 
   @Test
-  public void shouldRestructurePerson() {
+  void shouldRestructurePerson() {
     Mapper<PersonFlat, Family> mapper = Mapping.from(PersonFlat.class)
         .to(Family.class)
         .omitOtherSourceProperties()

--- a/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
+++ b/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
@@ -1,9 +1,9 @@
 package com.remondis.remap.restructure.ndepth;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
+++ b/src/test/java/com/remondis/remap/restructure/ndepth/NdepthRestructureTest.java
@@ -13,10 +13,10 @@ import com.remondis.remap.restructure.Address;
 import com.remondis.remap.restructure.Bean;
 import com.remondis.resample.Samples;
 
-public class NdepthRestructureTest {
+class NdepthRestructureTest {
 
   @Test
-  public void shouldReturnMappingModel_n_depth_for_Restructure_n_depth() {
+  void shouldReturnMappingModel_n_depth_for_Restructure_n_depth() {
 
     Mapper<Bean, Bean2> mapper = createMapper();
     MappingModel<Bean, Bean2>.TransformationSearchResult result = mapper.getMappingModel()
@@ -25,7 +25,7 @@ public class NdepthRestructureTest {
   }
 
   @Test
-  public void shouldRestructure_n_depth() {
+  void shouldRestructure_n_depth() {
 
     Mapper<Bean, Bean2> mapper = createMapper();
 
@@ -50,7 +50,7 @@ public class NdepthRestructureTest {
   }
 
   @Test
-  public void shouldAssertRestructuring() {
+  void shouldAssertRestructuring() {
     AssertMapping.of(createMapper())
         .expectOtherSourceFieldsToBeOmitted()
         .expectRestructure(Bean2::getPerson)
@@ -60,7 +60,7 @@ public class NdepthRestructureTest {
   }
 
   @Test
-  public void shouldComplainAboutUnexpectedMappingConfiguration() {
+  void shouldComplainAboutUnexpectedMappingConfiguration() {
     assertThatThrownBy(() -> AssertMapping.of(createMapper())
         .expectOtherSourceFieldsToBeOmitted()
         .expectRestructure(Bean2::getPerson)
@@ -72,7 +72,7 @@ public class NdepthRestructureTest {
   }
 
   @Test
-  public void shouldCompainAboutDifferentMappings() {
+  void shouldCompainAboutDifferentMappings() {
     Mapper<Bean, Bean2> mapper = Mapping.from(Bean.class)
         .to(Bean2.class)
         .omitOtherSourceProperties()
@@ -99,7 +99,7 @@ public class NdepthRestructureTest {
   }
 
   @Test
-  public void shouldComplainAboutUnexpectedNestedMappingConfiguration() {
+  void shouldComplainAboutUnexpectedNestedMappingConfiguration() {
     assertThatThrownBy(() -> AssertMapping.of(createMapper())
         .expectOtherSourceFieldsToBeOmitted()
         .expectRestructure(Bean2::getPerson)

--- a/src/test/java/com/remondis/remap/setOperation/SetOperationTest.java
+++ b/src/test/java/com/remondis/remap/setOperation/SetOperationTest.java
@@ -1,11 +1,11 @@
 package com.remondis.remap.setOperation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/setOperation/SetOperationTest.java
+++ b/src/test/java/com/remondis/remap/setOperation/SetOperationTest.java
@@ -11,7 +11,7 @@ import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class SetOperationTest {
+class SetOperationTest {
 
   private static final String STATIC_STRING_VALUE = "static-string-value";
   private static final RuntimeException RUNTIME_EXCEPTION = new RuntimeException("Thrown for test purposes.");
@@ -19,7 +19,7 @@ public class SetOperationTest {
   private static final String ANOTHER_STRING = "anotherString";
 
   @Test
-  public void shouldHandleFunctionExceptionInAsserts() {
+  void shouldHandleFunctionExceptionInAsserts() {
     A a = a();
     Mapper<A, B> aToBmapper = Mapping.from(A.class)
         .to(B.class)
@@ -46,7 +46,7 @@ public class SetOperationTest {
   }
 
   @Test
-  public void shouldDetectMissingSetValueAssert() {
+  void shouldDetectMissingSetValueAssert() {
     A a = a();
     Mapper<A, B> aToBmapper = aToBmapper();
     B b = aToBmapper.map(a);
@@ -65,7 +65,7 @@ public class SetOperationTest {
   }
 
   @Test
-  public void shouldDetectMissingSetWithSupplierAssert() {
+  void shouldDetectMissingSetWithSupplierAssert() {
     A a = a();
     Mapper<A, B> aToBmapper = aToBmapper();
     B b = aToBmapper.map(a);
@@ -84,7 +84,7 @@ public class SetOperationTest {
   }
 
   @Test
-  public void shouldDetectMissingSetWithFunctionAssert() {
+  void shouldDetectMissingSetWithFunctionAssert() {
     A a = a();
     Mapper<A, B> aToBmapper = aToBmapper();
     B b = aToBmapper.map(a);
@@ -103,7 +103,7 @@ public class SetOperationTest {
   }
 
   @Test
-  public void shouldMapAndSetCorrectly() {
+  void shouldMapAndSetCorrectly() {
     A a = a();
     Mapper<A, B> aToBmapper = aToBmapper();
     B b = aToBmapper.map(a);

--- a/src/test/java/com/remondis/remap/spring/SpringExampleTest.java
+++ b/src/test/java/com/remondis/remap/spring/SpringExampleTest.java
@@ -17,7 +17,7 @@ import com.remondis.remap.Mapping;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class SpringExampleTest {
+class SpringExampleTest {
 
   @Autowired
   Mapper<Person, Human> mapper1;
@@ -26,14 +26,14 @@ public class SpringExampleTest {
   Mapper<Human, Person> mapper2;
 
   @Test
-  public void testPersonHumanMapper() throws IOException {
+  void testPersonHumanMapper() throws IOException {
     Person person = new Person("Bob");
     Human human = mapper1.map(person);
     assertThat(human.getName()).isEqualTo("Bob");
   }
 
   @Test
-  public void testHumanPersonMapper() {
+  void testHumanPersonMapper() {
     Human human = new Human("ET");
     Person person = mapper2.map(human);
     assertThat(person.getName()).isEqualTo("ET");

--- a/src/test/java/com/remondis/remap/test/MapperTests.java
+++ b/src/test/java/com/remondis/remap/test/MapperTests.java
@@ -13,7 +13,7 @@ import com.remondis.remap.test.MapperTests.PersonWithAddress.Address;
 public class MapperTests {
 
   @Test
-  public void mapsBeansWithSameFields() {
+  void mapsBeansWithSameFields() {
     Mapper<BeanWithConstructors, BeanWithEmptyConstructor> mapper = Mapping.from(BeanWithConstructors.class)
         .to(BeanWithEmptyConstructor.class)
         .mapper();
@@ -23,7 +23,7 @@ public class MapperTests {
   }
 
   @Test
-  public void mapsWithDefaultConstructor() {
+  void mapsWithDefaultConstructor() {
     // when a bean does not have a constructor, it should work with using the
     // default constructor
     Mapper<BeanWithConstructors, BeanWithoutConstructor> mapper = Mapping.from(BeanWithConstructors.class)
@@ -35,7 +35,7 @@ public class MapperTests {
   }
 
   @Test
-  public void failsWithoutEmptyConstructor() {
+  void failsWithoutEmptyConstructor() {
     // when a bean does not have an empty constructor, mapping should fail
     assertThrows(MappingException.class, () -> Mapping.from(BeanWithConstructors.class)
         .to(BeanWithoutEmptyConstructor.class)
@@ -43,14 +43,14 @@ public class MapperTests {
   }
 
   @Test
-  public void failsOnUnspecifiedFields() {
+  void failsOnUnspecifiedFields() {
     assertThrows(MappingException.class, () -> Mapping.from(BeanWithConstructors.class)
         .to(Person.class)
         .mapper());
   }
 
   @Test
-  public void reassignsFields() {
+  void reassignsFields() {
     Mapper<BeanWithConstructors, Person> mapper = Mapping.from(BeanWithConstructors.class)
         .to(Person.class)
         .reassign(BeanWithConstructors::getIntField)
@@ -65,7 +65,7 @@ public class MapperTests {
   }
 
   @Test
-  public void omitsSourceField() {
+  void omitsSourceField() {
     Mapper<Person, Name> mapper = Mapping.from(Person.class)
         .to(Name.class)
         .omitInSource(Person::getAge)
@@ -76,7 +76,7 @@ public class MapperTests {
   }
 
   @Test
-  public void omitsDestinationField() {
+  void omitsDestinationField() {
     Mapper<Name, Person> mapper = Mapping.from(Name.class)
         .to(Person.class)
         .omitInDestination(Person::getAge)
@@ -87,14 +87,14 @@ public class MapperTests {
   }
 
   @Test
-  public void failsOnMissingNestedMapper() {
+  void failsOnMissingNestedMapper() {
     assertThrows(MappingException.class, () -> Mapping.from(PersonWithAddress.class)
         .to(HumanWithAddress.class)
         .mapper());
   }
 
   @Test
-  public void mapsNested() {
+  void mapsNested() {
     Mapper<PersonWithAddress, HumanWithAddress> mapper = Mapping.from(PersonWithAddress.class)
         .to(HumanWithAddress.class)
         .useMapper(Mapping.from(PersonWithAddress.Address.class)
@@ -113,7 +113,7 @@ public class MapperTests {
   }
 
   @Test
-  public void replaces() {
+  void replaces() {
     Mapper<PersonWithAddress, PersonWithFoo> mapper = Mapping.from(PersonWithAddress.class)
         .to(PersonWithFoo.class)
         .replace(PersonWithAddress::getAddress, PersonWithFoo::getFoo)

--- a/src/test/java/com/remondis/remap/test/MapperTests.java
+++ b/src/test/java/com/remondis/remap/test/MapperTests.java
@@ -1,8 +1,9 @@
 package com.remondis.remap.test;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
@@ -33,19 +34,19 @@ public class MapperTests {
     assertThat(result.getStringField()).isEqualTo("42");
   }
 
-  @Test(expected = MappingException.class)
+  @Test
   public void failsWithoutEmptyConstructor() {
     // when a bean does not have an empty constructor, mapping should fail
-    Mapping.from(BeanWithConstructors.class)
+    assertThrows(MappingException.class, () -> Mapping.from(BeanWithConstructors.class)
         .to(BeanWithoutEmptyConstructor.class)
-        .mapper();
+        .mapper());
   }
 
-  @Test(expected = MappingException.class)
+  @Test
   public void failsOnUnspecifiedFields() {
-    Mapping.from(BeanWithConstructors.class)
+    assertThrows(MappingException.class, () -> Mapping.from(BeanWithConstructors.class)
         .to(Person.class)
-        .mapper();
+        .mapper());
   }
 
   @Test
@@ -85,11 +86,11 @@ public class MapperTests {
     assertThat(person.getName()).isEqualTo("Bob");
   }
 
-  @Test(expected = MappingException.class)
+  @Test
   public void failsOnMissingNestedMapper() {
-    Mapping.from(PersonWithAddress.class)
+    assertThrows(MappingException.class, () -> Mapping.from(PersonWithAddress.class)
         .to(HumanWithAddress.class)
-        .mapper();
+        .mapper());
   }
 
   @Test

--- a/src/test/java/com/remondis/remap/utils/mapOver/MapOverTest.java
+++ b/src/test/java/com/remondis/remap/utils/mapOver/MapOverTest.java
@@ -1,9 +1,9 @@
 package com.remondis.remap.utils.mapOver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.basic.A;
 import com.remondis.remap.basic.B;

--- a/src/test/java/com/remondis/remap/utils/mapOver/MapOverTest.java
+++ b/src/test/java/com/remondis/remap/utils/mapOver/MapOverTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.basic.A;
 import com.remondis.remap.basic.B;
 
-public class MapOverTest {
+class MapOverTest {
   @Test
-  public void shouldMapFromSourceToTarget() {
+  void shouldMapFromSourceToTarget() {
     A a1 = new A("moreInA1", "stringA1", 1, 2, 1L, new B("stringB1", 1, 1));
     A a2 = new A("moreInA2", "stringA2", 1, 2, 1L, new B("stringB2", 1, 1));
 

--- a/src/test/java/com/remondis/remap/visibility/VisibilityTest.java
+++ b/src/test/java/com/remondis/remap/visibility/VisibilityTest.java
@@ -1,8 +1,8 @@
 package com.remondis.remap.visibility;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;

--- a/src/test/java/com/remondis/remap/visibility/VisibilityTest.java
+++ b/src/test/java/com/remondis/remap/visibility/VisibilityTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 
-public class VisibilityTest {
+class VisibilityTest {
   @Test
-  public void testVisibility() {
+  void testVisibility() {
     Mapper<C, CResource> mapper = Mapping.from(C.class)
         .to(CResource.class)
         .mapper();

--- a/src/test/java/com/remondis/remap/writeNull/WriteNullTest.java
+++ b/src/test/java/com/remondis/remap/writeNull/WriteNullTest.java
@@ -1,12 +1,12 @@
 package com.remondis.remap.writeNull;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.remondis.remap.AssertMapping;
 import com.remondis.remap.Mapper;

--- a/src/test/java/com/remondis/remap/writeNull/WriteNullTest.java
+++ b/src/test/java/com/remondis/remap/writeNull/WriteNullTest.java
@@ -13,10 +13,10 @@ import com.remondis.remap.Mapper;
 import com.remondis.remap.Mapping;
 import com.remondis.remap.MappingConfiguration;
 
-public class WriteNullTest {
+class WriteNullTest {
 
   @Test
-  public void shouldWriteNull() {
+  void shouldWriteNull() {
     Mapper<Source, Destination> mapper = Mapping.from(Source.class)
         .to(Destination.class)
         .writeNullIfSourceIsNull()
@@ -37,7 +37,7 @@ public class WriteNullTest {
   }
 
   @Test
-  public void shouldComplainAboutWrongNullHandling() {
+  void shouldComplainAboutWrongNullHandling() {
 
     MappingConfiguration<Source, Destination> configuration = Mapping.from(Source.class)
         .to(Destination.class);


### PR DESCRIPTION
Convert all remaining JUnit 4-style test code (@Test, @Before, @Ignore, @FixMethodOrder, org.junit.Assert.*) to JUnit Jupiter equivalents, since the prior JUnit 4 -> 5 migration only added junit-vintage-engine to run the old-style tests rather than converting them. Bump junit-jupiter to 6.1.1 and drop junit-vintage-engine, which is no longer needed and is deprecated upstream.

- @Before/@After/@BeforeClass/@AfterClass -> @BeforeEach/@AfterEach/@BeforeAll/@AfterAll
- @Ignore -> @Disabled
- @FixMethodOrder(MethodSorters.NAME_ASCENDING) -> @TestMethodOrder(MethodOrderer.MethodName.class)
- @Test(expected = X.class) -> assertThrows(...)/assertThatThrownBy(...)
- org.junit.Assert.* -> org.junit.jupiter.api.Assertions.* (message-arg now trails)
- Hamcrest-style assertThat -> org.hamcrest.MatcherAssert.assertThat

All 197 tests pass (1 pre-existing @Disabled test skipped).